### PR TITLE
Correct service binding annotations

### DIFF
--- a/config/crd/patches/service_binding_annotations.yaml
+++ b/config/crd/patches/service_binding_annotations.yaml
@@ -3,5 +3,5 @@ kind: CustomResourceDefinition
 metadata:
   name: dbaasconnections.dbaas.redhat.com
   annotations:
-    service.binding/credentials: 'path={.status.credentialsRef},objectType=Secret'
-    service.binding/configuration: 'path={.status.connectionInfoRef},objectType=ConfigMap'
+    service.binding/credentials: 'path={.status.credentialsRef.name},objectType=Secret'
+    service.binding/configuration: 'path={.status.connectionInfoRef.name},objectType=ConfigMap'


### PR DESCRIPTION
## Description
The current service binding annotations are:
service.binding/configuration: path={.status.connectionInfoRef},objectType=ConfigMap
service.binding/credentials: path={.status.credentialsRef},objectType=Secret

They shoud use the corresponding name instead as otherwise SBO won't be able to find the corresponding configmap and secret:
service.binding/configuration: path={.status.connectionInfoRef.name},objectType=ConfigMap
service.binding/credentials: path={.status.credentialsRef.name},objectType=Secret

## Verification Steps
Changes have been deployed in the lab and test done.

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
~~ [ ] All acceptance criteria specified in JIRA or in issue number have been completed
~~ [ ] Unit tests added that prove the fix is effective or the feature works 
~~  [ ] Documentation added for the feature
- [ ] all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer