### PR TITLE
open DBaaSProvider view to all auth'd users

### DIFF
--- a/config/rbac/dbaasprovider_viewer_role_binding.yaml
+++ b/config/rbac/dbaasprovider_viewer_role_binding.yaml
@@ -1,0 +1,13 @@
+# allow OCP console UX to fetch providers list regardless of current namespace
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: dbaasprovider-viewers
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: dbaasprovider-viewer-role
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: system:authenticated

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -9,6 +9,8 @@ resources:
 - role_binding.yaml
 - leader_election_role.yaml
 - leader_election_role_binding.yaml
+- dbaasprovider_viewer_role.yaml
+- dbaasprovider_viewer_role_binding.yaml
 # Comment the following 4 lines if you want to disable
 # the auth proxy (https://github.com/brancz/kube-rbac-proxy)
 # which protects your /metrics endpoint.


### PR DESCRIPTION
## Description
Add view permissions for DBaaSProvider resources for all authenticated users so that the UX can fetch & list providers regardless of the current namespace. Refer to security ADR for further info under 'Tenant Registration'.

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)