### PR TITLE
[DBAAS-141] improve reconciles of inventory and tenant objects

### DIFF
--- a/controllers/dbaasinventory_controller.go
+++ b/controllers/dbaasinventory_controller.go
@@ -18,21 +18,19 @@ package controllers
 
 import (
 	"context"
-	"reflect"
 
+	"github.com/RHEcosystemAppEng/dbaas-operator/api/v1alpha1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
-
-	"github.com/RHEcosystemAppEng/dbaas-operator/api/v1alpha1"
 )
 
 // DBaaSInventoryReconciler reconciles a DBaaSInventory object
 type DBaaSInventoryReconciler struct {
 	*DBaaSReconciler
-	// TenantCtrl controller.Controller
 }
 
 //+kubebuilder:rbac:groups=dbaas.redhat.com,resources=*,verbs=get;list;watch;create;update;patch;delete
@@ -49,8 +47,14 @@ type DBaaSInventoryReconciler struct {
 func (r *DBaaSInventoryReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	logger := ctrl.LoggerFrom(ctx, "DBaaS Inventory", req.NamespacedName)
 
-	// only reconcile an Inventory if it's installed to a Tenant object's inventoryNamespace
-	if contains(TenantInventoryNS, req.Namespace) {
+	tenantList, err := r.tenantListByInventoryNS(ctx, req.Namespace)
+	if err != nil {
+		logger.Error(err, "unable to list tenants")
+		return ctrl.Result{}, err
+	}
+
+	// continue only if the inventory is in a valid tenant namespace
+	if len(tenantList.Items) > 0 {
 		var inventory v1alpha1.DBaaSInventory
 		if err := r.Get(ctx, req.NamespacedName, &inventory); err != nil {
 			if errors.IsNotFound(err) {
@@ -65,33 +69,22 @@ func (r *DBaaSInventoryReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		//
 		// Inventory RBAC
 		//
-		role, rolebinding := inventoryRbacObjs(inventory)
-		var roleObj rbacv1.Role
-		if exists, err := r.createRbacObj(&role, &roleObj, &inventory, ctx); err != nil {
+		if err := r.reconcileInventoryRbacObjs(ctx, inventory, tenantList); err != nil {
 			return ctrl.Result{}, err
-		} else if exists {
-			if !reflect.DeepEqual(role.Rules, roleObj.Rules) {
-				roleObj.Rules = role.Rules
-				if err := r.updateObject(&roleObj, ctx); err != nil {
-					logger.Error(err, "Error updating resource", roleObj.Name, roleObj.Namespace)
-					return ctrl.Result{}, err
-				}
-				logger.V(1).Info(roleObj.Kind+" resource updated", roleObj.Name, roleObj.Namespace)
-			}
 		}
-		var roleBindingObj rbacv1.RoleBinding
-		if exists, err := r.createRbacObj(&rolebinding, &roleBindingObj, &inventory, ctx); err != nil {
+
+		// Get list of DBaaSInventories from namespace
+		var inventoryList v1alpha1.DBaaSInventoryList
+		if err := r.List(ctx, &inventoryList, &client.ListOptions{Namespace: req.Namespace}); err != nil {
+			logger.Error(err, "Error fetching DBaaS Inventory List for reconcile")
 			return ctrl.Result{}, err
-		} else if exists {
-			if !reflect.DeepEqual(rolebinding.RoleRef, roleBindingObj.RoleRef) ||
-				!reflect.DeepEqual(rolebinding.Subjects, roleBindingObj.Subjects) {
-				roleBindingObj.RoleRef = rolebinding.RoleRef
-				roleBindingObj.Subjects = rolebinding.Subjects
-				if err := r.updateObject(&roleBindingObj, ctx); err != nil {
-					logger.Error(err, "Error updating resource", roleBindingObj.Name, roleBindingObj.Namespace)
-					return ctrl.Result{}, err
-				}
-				logger.V(1).Info(roleBindingObj.Kind+" resource updated", roleBindingObj.Name, roleBindingObj.Namespace)
+		}
+
+		// Reconcile each pertinent tenant to ensure proper RBAC is created
+		for _, tenant := range tenantList.Items {
+			// should we return anything on err for these reconciles?
+			if err := r.reconcileTenantRbacObjs(ctx, tenant, getAllAuthzFromInventoryList(inventoryList, tenant)); err != nil {
+				return ctrl.Result{}, err
 			}
 		}
 
@@ -149,11 +142,10 @@ func (r *DBaaSInventoryReconciler) SetupWithManager(mgr ctrl.Manager) (controlle
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&v1alpha1.DBaaSInventory{}).
 		Build(r)
-	// ?? should we add a predicate to only reconcile inventories in a TenantNS ? can we?
 }
 
 // gets rbac objects for an inventory's users
-func inventoryRbacObjs(inventory v1alpha1.DBaaSInventory) (rbacv1.Role, rbacv1.RoleBinding) {
+func inventoryRbacObjs(inventory v1alpha1.DBaaSInventory, tenantList v1alpha1.DBaaSTenantList) (rbacv1.Role, rbacv1.RoleBinding) {
 	role := rbacv1.Role{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "dbaas-" + inventory.Name + "-inventory-viewer",
@@ -192,7 +184,7 @@ func inventoryRbacObjs(inventory v1alpha1.DBaaSInventory) (rbacv1.Role, rbacv1.R
 	// if inventory.Spec.Authz is nil, use tenant defaults for view access to the Inventory object
 	var users, groups []string
 	if inventory.Spec.Authz.Users == nil && inventory.Spec.Authz.Groups == nil {
-		for _, tenant := range TenantList.Items {
+		for _, tenant := range tenantList.Items {
 			if tenant.Spec.InventoryNamespace == inventory.Namespace {
 				users = append(users, tenant.Spec.Authz.Developer.Users...)
 				groups = append(groups, tenant.Spec.Authz.Developer.Groups...)

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -129,7 +129,6 @@ var _ = BeforeSuite(func() {
 
 	err = (&DBaaSTenantReconciler{
 		DBaaSReconciler: dRec,
-		InventoryCtrl:   inventoryCtrl,
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 

--- a/main.go
+++ b/main.go
@@ -114,7 +114,6 @@ func main() {
 	}
 	err = (&controllers.DBaaSTenantReconciler{
 		DBaaSReconciler: DBaaSReconciler,
-		InventoryCtrl:   inventoryCtrl,
 	}).SetupWithManager(mgr)
 	if err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "DBaaSTenant")


### PR DESCRIPTION
Signed-off-by: Tommy Hughes <tohughes@redhat.com>

## Description
We need to ensure tenant/inventory rbac is properly configured immediately upon any authz modification. This change accomplishes that by doing the following:

- when an inventory in a tenant's namespace is reconciled, we also reconcile all related tenant rbac objects.
- when a tenant is reconciled, we also reconcile all related inventory rbac objects.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] All acceptance criteria specified in JIRA or in issue number have been completed
- [x] Unit tests added that prove the fix is effective or the feature works 
- [ ] Documentation added for the feature
- [x] all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer