### PR TITLE
Upgrade opm to version 1.17.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -201,7 +201,7 @@ ifeq (,$(shell which opm 2>/dev/null))
 	set -e ;\
 	mkdir -p $(dir $(OPM)) ;\
 	OS=$(shell go env GOOS) && ARCH=$(shell go env GOARCH) && \
-	curl -sSLo $(OPM) https://github.com/operator-framework/operator-registry/releases/download/v1.15.1/$${OS}-$${ARCH}-opm ;\
+	curl -sSLo $(OPM) https://github.com/operator-framework/operator-registry/releases/download/v1.17.3/$${OS}-$${ARCH}-opm ;\
 	chmod +x $(OPM) ;\
 	}
 else


### PR DESCRIPTION
This PR is to upgrade opm to version 1.17.3. Existing version 1.15.1 causes the catalog-build phase to fail on Mac OS.
./bin/opm index add --container-tool docker --mode semver --tag quay.io/sgahlot/dbaas-operator-catalog:v0.0.1 --bundles quay.io/sgahlot/dbaas-operator-bundle:v0.0.1
INFO[0000] building the index                            bundles="[quay.io/sgahlot/dbaas-operator-bundle:v0.0.1]"
Error: Binary was compiled with 'CGO_ENABLED=0', go-sqlite3 requires cgo to work. This is a stub
Usage:
  opm index add [flags]

This build error is fixed with the new version.