### PR TITLE
add role check for edit & list verbs

### DIFF
--- a/controllers/dbaasinventory_controller.go
+++ b/controllers/dbaasinventory_controller.go
@@ -154,13 +154,7 @@ func inventoryRbacObjs(inventory v1alpha1.DBaaSInventory, tenantList v1alpha1.DB
 		Rules: []rbacv1.PolicyRule{
 			{
 				APIGroups:     []string{v1alpha1.GroupVersion.Group},
-				Resources:     []string{"dbaasinventories"},
-				ResourceNames: []string{inventory.Name},
-				Verbs:         []string{"get", "list", "watch"},
-			},
-			{
-				APIGroups:     []string{v1alpha1.GroupVersion.Group},
-				Resources:     []string{"dbaasinventories/status"},
+				Resources:     []string{"dbaasinventories", "dbaasinventories/status"},
 				ResourceNames: []string{inventory.Name},
 				Verbs:         []string{"get"},
 			},

--- a/controllers/dbaasinventory_controller_test.go
+++ b/controllers/dbaasinventory_controller_test.go
@@ -34,23 +34,7 @@ func TestInventoryRbacObjs(t *testing.T) {
 
 	// Expect(err).NotTo(HaveOccurred())
 	namespace := "test-ns"
-	tenantList := v1alpha1.DBaaSTenantList{
-		Items: []v1alpha1.DBaaSTenant{
-			{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "cluster",
-				},
-				Spec: v1alpha1.DBaaSTenantSpec{
-					InventoryNamespace: "wrong",
-					Authz: v1alpha1.DBaasAuthz{
-						Developer: v1alpha1.DBaasUsersGroups{
-							Groups: []string{"system:authenticated"},
-						},
-					},
-				},
-			},
-		},
-	}
+	tenantList := createTestTenantList()
 
 	// nil spec.authz w/ default tenant set to wrong namespace
 	inventory := v1alpha1.DBaaSInventory{
@@ -253,3 +237,11 @@ var _ = Describe("DBaaSInventory controller", func() {
 		})
 	})
 })
+
+func createTestTenantList() v1alpha1.DBaaSTenantList {
+	return v1alpha1.DBaaSTenantList{
+		Items: []v1alpha1.DBaaSTenant{
+			getDefaultTenant("wrong"),
+		},
+	}
+}


### PR DESCRIPTION
Signed-off-by: Tommy Hughes <tohughes@redhat.com>

## Description
- added check to ensure we aren't creating roles with edit permissions, mostly to check against potential future changes.
- also, remove unnecessary list/watch verbs from existing tenant roles.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA or in issue number have been completed
- [x] Unit tests added that prove the fix is effective or the feature works 
- [ ] Documentation added for the feature
- [x] all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer