### PR TITLE
adding further restrictions to pods/containers where recommended

### DIFF
--- a/bundle/manifests/dbaas-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/dbaas-operator.clusterserviceversion.yaml
@@ -465,6 +465,8 @@ spec:
                     memory: 100Mi
                 securityContext:
                   allowPrivilegeEscalation: false
+                  readOnlyRootFilesystem: true
+                  runAsNonRoot: true
               securityContext:
                 runAsNonRoot: true
               serviceAccountName: dbaas-operator-controller-manager

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -24,3 +24,7 @@ spec:
         - "--health-probe-bind-address=:8081"
         - "--metrics-bind-address=127.0.0.1:8080"
         - "--leader-elect"
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -35,6 +35,8 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
## Description
Updating some securityContext flags in kustomization templates/CSV per recommendations. Have deployed bundle to OSD 4.8.13 and tested e2e successfully. Here's the resultant CSV container section from the cluster when tested:
```yaml
spec:
spec:
    containers:
      - args:
          - '--secure-listen-address=0.0.0.0:8443'
          - '--upstream=http://127.0.0.1:8080/'
          - '--logtostderr=true'
          - '--v=10'
        image: 'registry.redhat.io/openshift4/ose-kube-rbac-proxy:v4.8'
        name: kube-rbac-proxy
        ports:
          - containerPort: 8443
            name: https
            protocol: TCP
        resources: {}
      - resources:
          limits:
            cpu: 100m
            memory: 250Mi
          requests:
            cpu: 100m
            memory: 100Mi
        readinessProbe:
          httpGet:
            path: /readyz
            port: 8081
          initialDelaySeconds: 5
          periodSeconds: 10
        name: manager
        command:
          - /manager
        livenessProbe:
          httpGet:
            path: /healthz
            port: 8081
          initialDelaySeconds: 15
          periodSeconds: 20
        env:
          - name: INSTALL_NAMESPACE
            valueFrom:
              fieldRef:
                fieldPath: metadata.namespace
        securityContext:
          allowPrivilegeEscalation: false
          readOnlyRootFilesystem: true
          runAsNonRoot: true
        ports:
          - containerPort: 9443
            name: webhook-server
            protocol: TCP
        image: 'quay.io/jary/dbaas-operator:v0.0.99'
        args:
          - '--health-probe-bind-address=:8081'
          - '--metrics-bind-address=127.0.0.1:8080'
          - '--leader-elect'
    securityContext:
      runAsNonRoot: true
    serviceAccountName: dbaas-operator-controller-manager
    terminationGracePeriodSeconds: 10
```