### PR TITLE
DBAAS-175 Add validation logic to DBaaSInventory creation with webhook

### DIFF
--- a/PROJECT
+++ b/PROJECT
@@ -28,6 +28,9 @@ resources:
   kind: DBaaSInventory
   path: github.com/RHEcosystemAppEng/dbaas-operator/api/v1alpha1
   version: v1alpha1
+  webhooks:
+    validation: true
+    webhookVersion: v1
 - api:
     crdVersion: v1
   controller: true

--- a/api/v1alpha1/dbaasinventory_webhook.go
+++ b/api/v1alpha1/dbaasinventory_webhook.go
@@ -1,0 +1,98 @@
+/*
+Copyright 2021, Red Hat.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+)
+
+// log is for logging in this package.
+var dbaasinventorylog = logf.Log.WithName("dbaasinventory-resource")
+var apiClient client.Client = nil
+
+func (r *DBaaSInventory) SetupWebhookWithManager(mgr ctrl.Manager) error {
+	if apiClient == nil {
+		apiClient = mgr.GetClient()
+	}
+	return ctrl.NewWebhookManagedBy(mgr).
+		For(r).
+		Complete()
+}
+
+//+kubebuilder:webhook:path=/validate-dbaas-redhat-com-v1alpha1-dbaasinventory,mutating=false,failurePolicy=fail,sideEffects=None,groups=dbaas.redhat.com,resources=dbaasinventories,verbs=create;update,versions=v1alpha1,name=vdbaasinventory.kb.io,admissionReviewVersions=v1
+//+kubebuilder:rbac:groups="",resources=secrets,verbs=get
+
+var _ webhook.Validator = &DBaaSInventory{}
+
+// ValidateCreate implements webhook.Validator so a webhook will be registered for the type
+func (r *DBaaSInventory) ValidateCreate() error {
+	dbaasinventorylog.Info("validate create", "name", r.Name)
+	return validate(r)
+}
+
+// ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
+func (r *DBaaSInventory) ValidateUpdate(old runtime.Object) error {
+	dbaasinventorylog.Info("validate update", "name", r.Name)
+	return validate(r)
+}
+
+// ValidateDelete implements webhook.Validator so a webhook will be registered for the type
+func (r *DBaaSInventory) ValidateDelete() error {
+	dbaasinventorylog.Info("validate delete", "name", r.Name)
+	return nil
+}
+
+func validate(inv *DBaaSInventory) error {
+	// Retrieve the secret object
+	secret := &corev1.Secret{}
+	ns := inv.Spec.DBaaSInventorySpec.CredentialsRef.Namespace
+	if len(ns) == 0 {
+		ns = inv.Namespace
+	}
+	if err := apiClient.Get(context.TODO(), types.NamespacedName{Name: inv.Spec.DBaaSInventorySpec.CredentialsRef.Name, Namespace: ns}, secret); err != nil {
+		return err
+	}
+	// Retrieve the provider object
+	provider := &DBaaSProvider{}
+	if err := apiClient.Get(context.TODO(), types.NamespacedName{Name: inv.Spec.ProviderRef.Name, Namespace: ""}, provider); err != nil {
+		return err
+	}
+	return validateMandatoryFields(inv, secret, provider)
+}
+
+func validateMandatoryFields(inv *DBaaSInventory, secret *corev1.Secret, provider *DBaaSProvider) error {
+	for _, credField := range provider.Spec.CredentialFields {
+		if credField.Required {
+			if value, ok := secret.Data[credField.Key]; !ok || len(value) == 0 {
+				//Required key is missing
+				msg := fmt.Sprintf("credentialsRef is invalid: %s is required in secret %s", credField.Key, secret.Name)
+				return field.Invalid(field.NewPath("spec").Child("credentialsRef"), *(inv.Spec.CredentialsRef), msg)
+			}
+		}
+	}
+	return nil
+}

--- a/api/v1alpha1/dbaasinventory_webhook_test.go
+++ b/api/v1alpha1/dbaasinventory_webhook_test.go
@@ -1,0 +1,277 @@
+/*
+Copyright 2021, Red Hat.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	testSecretName       = "testsecret"
+	testSecretNameUpdate = "testsecretupdate"
+	testProviderName     = "mongodb-atlas"
+	testInventoryKind    = "MongoDBAtlasInventory"
+	testConnectionKind   = "MongoDBAtlasConnection"
+)
+
+var (
+	testProvider = DBaaSProvider{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testProviderName,
+			Namespace: testNamespace,
+		},
+		Spec: DBaaSProviderSpec{
+			Provider: DatabaseProvider{
+				Name: testProviderName,
+			},
+			InventoryKind:  testInventoryKind,
+			ConnectionKind: testConnectionKind,
+			CredentialFields: []CredentialField{
+				{
+					Key:      "field1",
+					Type:     "String",
+					Required: true,
+				},
+				{
+					Key:      "field2",
+					Type:     "String",
+					Required: false,
+				},
+			},
+		},
+	}
+	testSecret = corev1.Secret{
+		TypeMeta: metav1.TypeMeta{
+			Kind: "Opaque",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testSecretName,
+			Namespace: testNamespace,
+		},
+		Data: map[string][]byte{
+			"field1": []byte("test1"),
+			"field2": []byte("test2"),
+			"field3": []byte("test3"),
+		},
+	}
+	testSecret2 = corev1.Secret{
+		TypeMeta: metav1.TypeMeta{
+			Kind: "Opaque",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testSecretName,
+			Namespace: testNamespace,
+		},
+		Data: map[string][]byte{
+			"field2": []byte("test2"),
+			"field3": []byte("test3"),
+		},
+	}
+	testSecret2update = corev1.Secret{
+		TypeMeta: metav1.TypeMeta{
+			Kind: "Opaque",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testSecretNameUpdate,
+			Namespace: testNamespace,
+		},
+		Data: map[string][]byte{
+			"field2": []byte("test2"),
+			"field3": []byte("test3"),
+		},
+	}
+	testSecret3 = corev1.Secret{
+		TypeMeta: metav1.TypeMeta{
+			Kind: "Opaque",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testSecretName,
+			Namespace: testNamespace,
+		},
+		Data: map[string][]byte{
+			"field1": []byte("test1"),
+		},
+	}
+	testSecret3update = corev1.Secret{
+		TypeMeta: metav1.TypeMeta{
+			Kind: "Opaque",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testSecretNameUpdate,
+			Namespace: testNamespace,
+		},
+		Data: map[string][]byte{
+			"field1": []byte("test1"),
+		},
+	}
+	testDBaaSInventory = DBaaSInventory{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      inventoryName,
+			Namespace: testNamespace,
+		},
+		Spec: DBaaSOperatorInventorySpec{
+			ProviderRef: NamespacedName{
+				Name: testProviderName,
+			},
+			DBaaSInventorySpec: DBaaSInventorySpec{
+				CredentialsRef: &NamespacedName{
+					Name:      testSecretName,
+					Namespace: testNamespace,
+				},
+			},
+		},
+	}
+)
+
+var _ = Describe("DBaaSInventory Webhook", func() {
+	Context("creation succeeds",
+		func() {
+			BeforeEach(assertResourceCreation(&testProvider))
+			AfterEach(assertResourceDeletion(&testProvider))
+			Context("without optional fields", func() {
+				BeforeEach(assertResourceCreation(&testSecret3))
+				AfterEach(assertResourceDeletion(&testSecret3))
+				It("should succeed without optional fields", func() {
+					inv := testDBaaSInventory.DeepCopy()
+					inv.Name = "inv-no-optional"
+					err := k8sClient.Create(ctx, inv)
+					Expect(err).Should(BeNil())
+					assertResourceDeletion(inv)
+				})
+			})
+			Context("with optional fields", func() {
+				BeforeEach(assertResourceCreation(&testSecret))
+				AfterEach(assertResourceDeletion(&testSecret))
+				It("should succeed with optional fields", func() {
+					const suffix = "a"
+					secret := testSecret.DeepCopy()
+					secret.Name = "testsecret" + suffix
+					inv := testDBaaSInventory.DeepCopy()
+					inv.Name = "testinventory" + suffix
+					inv.Spec.CredentialsRef.Name = secret.Name
+					secret.SetResourceVersion("")
+					Expect(k8sClient.Create(ctx, secret)).Should(Succeed())
+					err := k8sClient.Get(ctx, client.ObjectKeyFromObject(secret), secret)
+					Expect(err).Should(BeNil())
+					inv.SetResourceVersion("")
+					err = k8sClient.Create(ctx, inv)
+					Expect(err).Should(BeNil())
+					assertResourceDeletion(inv)
+					assertResourceDeletion(secret)
+				})
+			})
+			Context("without credentialRef.namespace", func() {
+				It("should succeed without credentialRef.namespace", func() {
+					const suffix = "b"
+					secret := testSecret.DeepCopy()
+					secret.Name = "testsecret" + suffix
+					inv := testDBaaSInventory.DeepCopy()
+					inv.Name = "testinventory" + suffix
+					inv.Spec.CredentialsRef.Name = secret.Name
+					inv.Spec.CredentialsRef.Namespace = ""
+					secret.SetResourceVersion("")
+					Expect(k8sClient.Create(ctx, secret)).Should(Succeed())
+					err := k8sClient.Get(ctx, client.ObjectKeyFromObject(secret), secret)
+					Expect(err).Should(BeNil())
+					inv.SetResourceVersion("")
+					err = k8sClient.Create(ctx, inv)
+					Expect(err).Should(BeNil())
+					assertResourceDeletion(inv)
+					assertResourceDeletion(secret)
+				})
+			})
+		})
+	Context("creation fails",
+		func() {
+			BeforeEach(assertResourceCreation(&testSecret2))
+			BeforeEach(assertResourceCreation(&testProvider))
+			AfterEach(assertResourceDeletion(&testProvider))
+			AfterEach(assertResourceDeletion(&testSecret2))
+			It("missing required credential fields", func() {
+				err := k8sClient.Create(ctx, &testDBaaSInventory)
+				Expect(err).Should(MatchError("admission webhook \"vdbaasinventory.kb.io\" denied the request: spec.credentialsRef: Invalid value: v1alpha1.NamespacedName{Namespace:\"default\", Name:\"testsecret\"}: credentialsRef is invalid: field1 is required in secret testsecret"))
+			})
+		})
+	Context("update",
+		func() {
+			BeforeEach(assertResourceCreation(&testSecret))
+			BeforeEach(assertResourceCreation(&testProvider))
+			BeforeEach(assertResourceCreation(&testDBaaSInventory))
+			AfterEach(assertResourceDeletion(&testDBaaSInventory))
+			AfterEach(assertResourceDeletion(&testProvider))
+			AfterEach(assertResourceDeletion(&testSecret))
+			Context("nominal", func() {
+				BeforeEach(assertResourceCreation(&testSecret3update))
+				AfterEach(assertResourceDeletion(&testSecret3update))
+				It("Update CR should succeed", func() {
+					inv := testDBaaSInventory.DeepCopy()
+					Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(inv), inv)).Should(Succeed())
+					inv.Spec.CredentialsRef.Name = testSecretNameUpdate
+					err := k8sClient.Update(ctx, inv)
+					Expect(err).Should(BeNil())
+				})
+			})
+			Context("update fails", func() {
+				BeforeEach(assertResourceCreation(&testSecret2update))
+				AfterEach(assertResourceDeletion(&testSecret2update))
+				It("update fails with missing required credential fields", func() {
+					inv := testDBaaSInventory.DeepCopy()
+					Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(inv), inv)).Should(Succeed())
+					inv.Spec.CredentialsRef.Name = testSecretNameUpdate
+					err := k8sClient.Update(ctx, inv)
+					Expect(err).Should(MatchError("admission webhook \"vdbaasinventory.kb.io\" denied the request: spec.credentialsRef: Invalid value: v1alpha1.NamespacedName{Namespace:\"default\", Name:\"testsecretupdate\"}: credentialsRef is invalid: field1 is required in secret testsecretupdate"))
+				})
+			})
+		})
+})
+
+func assertResourceCreation(object client.Object) func() {
+	return func() {
+		By("creating resource")
+		object.SetResourceVersion("")
+		Expect(k8sClient.Create(ctx, object)).Should(Succeed())
+
+		By("checking the resource created")
+		Eventually(func() bool {
+			if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(object), object); err != nil {
+				return false
+			}
+			return true
+		}, timeout, interval).Should(BeTrue())
+	}
+}
+
+func assertResourceDeletion(object client.Object) func() {
+	return func() {
+		By("deleting resource")
+		Expect(k8sClient.Delete(ctx, object)).Should(Succeed())
+
+		By("checking the resource deleted")
+		Eventually(func() bool {
+			err := k8sClient.Get(ctx, client.ObjectKeyFromObject(object), object)
+			if err != nil && errors.IsNotFound(err) {
+				return true
+			}
+			return false
+		}, timeout, interval).Should(BeTrue())
+	}
+}

--- a/api/v1alpha1/dbaasprovider.go
+++ b/api/v1alpha1/dbaasprovider.go
@@ -129,7 +129,7 @@ type NamespacedName struct {
 	Namespace string `json:"namespace,omitempty"`
 
 	// The name for object of known type
-	Name string `json:"name,omitempty"`
+	Name string `json:"name"`
 }
 
 // DBaaSConnectionSpec defines the desired state of DBaaSConnection

--- a/api/v1alpha1/webhook_suite_test.go
+++ b/api/v1alpha1/webhook_suite_test.go
@@ -29,6 +29,8 @@ import (
 	. "github.com/onsi/gomega"
 
 	admissionv1beta1 "k8s.io/api/admission/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+
 	//+kubebuilder:scaffold:imports
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -87,6 +89,9 @@ var _ = BeforeSuite(func() {
 	err = admissionv1beta1.AddToScheme(scheme)
 	Expect(err).NotTo(HaveOccurred())
 
+	err = corev1.AddToScheme(scheme)
+	Expect(err).NotTo(HaveOccurred())
+
 	//+kubebuilder:scaffold:scheme
 
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme})
@@ -106,6 +111,9 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 
 	err = (&DBaaSConnection{}).SetupWebhookWithManager(mgr)
+	Expect(err).NotTo(HaveOccurred())
+
+	err = (&DBaaSInventory{}).SetupWebhookWithManager(mgr)
 	Expect(err).NotTo(HaveOccurred())
 
 	//+kubebuilder:scaffold:webhook

--- a/bundle/manifests/dbaas-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/dbaas-operator.clusterserviceversion.yaml
@@ -230,6 +230,12 @@ spec:
       - rules:
         - apiGroups:
           - ""
+          resources:
+          - secrets
+          verbs:
+          - get
+        - apiGroups:
+          - ""
           - authorization.openshift.io
           resources:
           - localresourceaccessreviews
@@ -575,3 +581,23 @@ spec:
     targetPort: 9443
     type: ValidatingAdmissionWebhook
     webhookPath: /validate-dbaas-redhat-com-v1alpha1-dbaasconnection
+  - admissionReviewVersions:
+    - v1
+    containerPort: 443
+    deploymentName: dbaas-operator-controller-manager
+    failurePolicy: Fail
+    generateName: vdbaasinventory.kb.io
+    rules:
+    - apiGroups:
+      - dbaas.redhat.com
+      apiVersions:
+      - v1alpha1
+      operations:
+      - CREATE
+      - UPDATE
+      resources:
+      - dbaasinventories
+    sideEffects: None
+    targetPort: 9443
+    type: ValidatingAdmissionWebhook
+    webhookPath: /validate-dbaas-redhat-com-v1alpha1-dbaasinventory

--- a/bundle/manifests/dbaas.redhat.com_dbaasconnections.yaml
+++ b/bundle/manifests/dbaas.redhat.com_dbaasconnections.yaml
@@ -49,6 +49,8 @@ spec:
                   namespace:
                     description: The namespace where object of known type is stored
                     type: string
+                required:
+                - name
                 type: object
             required:
             - instanceID

--- a/bundle/manifests/dbaas.redhat.com_dbaasinventories.yaml
+++ b/bundle/manifests/dbaas.redhat.com_dbaasinventories.yaml
@@ -61,6 +61,8 @@ spec:
                   namespace:
                     description: The namespace where object of known type is stored
                     type: string
+                required:
+                - name
                 type: object
               providerRef:
                 description: A reference to a DBaaSProvider CR
@@ -71,6 +73,8 @@ spec:
                   namespace:
                     description: The namespace where object of known type is stored
                     type: string
+                required:
+                - name
                 type: object
             required:
             - credentialsRef

--- a/config/crd/bases/dbaas.redhat.com_dbaasconnections.yaml
+++ b/config/crd/bases/dbaas.redhat.com_dbaasconnections.yaml
@@ -49,6 +49,8 @@ spec:
                   namespace:
                     description: The namespace where object of known type is stored
                     type: string
+                required:
+                - name
                 type: object
             required:
             - instanceID

--- a/config/crd/bases/dbaas.redhat.com_dbaasinventories.yaml
+++ b/config/crd/bases/dbaas.redhat.com_dbaasinventories.yaml
@@ -63,6 +63,8 @@ spec:
                   namespace:
                     description: The namespace where object of known type is stored
                     type: string
+                required:
+                - name
                 type: object
               providerRef:
                 description: A reference to a DBaaSProvider CR
@@ -73,6 +75,8 @@ spec:
                   namespace:
                     description: The namespace where object of known type is stored
                     type: string
+                required:
+                - name
                 type: object
             required:
             - credentialsRef

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -8,6 +8,12 @@ metadata:
 rules:
 - apiGroups:
   - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+- apiGroups:
+  - ""
   - authorization.openshift.io
   resources:
   - localresourceaccessreviews

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -25,3 +25,23 @@ webhooks:
     resources:
     - dbaasconnections
   sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-dbaas-redhat-com-v1alpha1-dbaasinventory
+  failurePolicy: Fail
+  name: vdbaasinventory.kb.io
+  rules:
+  - apiGroups:
+    - dbaas.redhat.com
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - dbaasinventories
+  sideEffects: None

--- a/controllers/reconcilers/constants.go
+++ b/controllers/reconcilers/constants.go
@@ -3,8 +3,8 @@ package reconcilers
 const (
 	INSTALL_NAMESPACE                        = "openshift-operators"
 	CATALOG_NAMESPACE                        = "openshift-marketplace"
-	MONGODB_ATLAS_CATLOG_IMG                 = "quay.io/mongodb/mongodb-atlas-kubernetes-dbaas-catalog:latest"
-	CRUNCHY_BRIDGE_CATLOG_IMG                = "quay.io/ecosystem-appeng/crunchy-bridge-operator-catalog:v0.0.2-dev"
+	MONGODB_ATLAS_CATALOG_IMG                = "quay.io/ecosystem-appeng/mongodb-atlas-operator-catalog:0.7.1-dev"
+	CRUNCHY_BRIDGE_CATALOG_IMG               = "quay.io/ecosystem-appeng/crunchy-bridge-operator-catalog:v0.0.2-dev"
 	DBAAS_DYNAMIC_PLUGIN_IMG                 = "quay.io/ecosystem-appeng/dbaas-dynamic-plugin:0.1.3"
 	DBAAS_DYNAMIC_PLUGIN_NAME                = "dbaas-dynamic-plugin"
 	DBAAS_DYNAMIC_PLUGIN_DISPLAY_NAME        = "OpenShift Database as a Service Dynamic Plugin"
@@ -14,7 +14,7 @@ const (
 	CONSOLE_TELEMETRY_PLUGIN_SEGMENT_KEY_ENV = "SEGMENT_KEY"
 	DBAAS_OPERATOR_VERSION_KEY_ENV           = "DBAAS_OPERATOR_VERSION"
 	CONSOLE_TELEMETRY_PLUGIN_SEGMENT_KEY     = "qejcCDG37ICCLIDsM1FcJDkd68hglCoK"
-	MONGODB_ATLAS_CSV                        = "mongodb-atlas-kubernetes.v0.1.0"
+	MONGODB_ATLAS_CSV                        = "mongodb-atlas-kubernetes.v0.7.1-dev"
 	CRUNCHY_BRIDGE_CSV                       = "crunchy-bridge-operator.v0.0.2-dev"
 	SERVICE_BINDING_CSV                      = "service-binding-operator.v0.10.0"
 )

--- a/controllers/reconcilers/crunchybridge_installation/crunchybridge_installation_reconciler.go
+++ b/controllers/reconcilers/crunchybridge_installation/crunchybridge_installation_reconciler.go
@@ -145,7 +145,7 @@ func (r *Reconciler) reconcileCatalogSource(ctx context.Context) (v1.PlatformsIn
 	_, err := controllerutil.CreateOrUpdate(ctx, r.client, catalogsource, func() error {
 		catalogsource.Spec = v1alpha1.CatalogSourceSpec{
 			SourceType:  v1alpha1.SourceTypeGrpc,
-			Image:       reconcilers.CRUNCHY_BRIDGE_CATLOG_IMG,
+			Image:       reconcilers.CRUNCHY_BRIDGE_CATALOG_IMG,
 			DisplayName: "Crunchy Bridge Operator",
 		}
 		return nil

--- a/controllers/reconcilers/mongodb_atlas_instalation/mongodb_atlas_installation_reconciler.go
+++ b/controllers/reconcilers/mongodb_atlas_instalation/mongodb_atlas_installation_reconciler.go
@@ -145,7 +145,7 @@ func (r *Reconciler) reconcileCatalogSource(ctx context.Context) (v1.PlatformsIn
 	_, err := controllerutil.CreateOrUpdate(ctx, r.client, catalogsource, func() error {
 		catalogsource.Spec = v1alpha1.CatalogSourceSpec{
 			SourceType:  v1alpha1.SourceTypeGrpc,
-			Image:       reconcilers.MONGODB_ATLAS_CATLOG_IMG,
+			Image:       reconcilers.MONGODB_ATLAS_CATALOG_IMG,
 			DisplayName: "MongoDB Atlas Operator",
 		}
 		return nil

--- a/main.go
+++ b/main.go
@@ -33,6 +33,7 @@ import (
 	oauthzclientv1 "github.com/openshift/client-go/authorization/clientset/versioned/typed/authorization/v1"
 	coreosv1 "github.com/operator-framework/api/pkg/operators/v1"
 	operatorframework "github.com/operator-framework/api/pkg/operators/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -100,6 +101,7 @@ func main() {
 		LeaderElectionID:       "e4addb06.redhat.com",
 		ClientDisableCacheFor: []client.Object{
 			&operatorframework.ClusterServiceVersion{},
+			&corev1.Secret{},
 		},
 	})
 	if err != nil {
@@ -157,6 +159,10 @@ func main() {
 	if os.Getenv("ENABLE_WEBHOOKS") != "false" {
 		if err = (&v1alpha1.DBaaSConnection{}).SetupWebhookWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create webhook", "webhook", "DBaaSConnection")
+			os.Exit(1)
+		}
+		if err = (&v1alpha1.DBaaSInventory{}).SetupWebhookWithManager(mgr); err != nil {
+			setupLog.Error(err, "unable to create webhook", "webhook", "DBaaSInventory")
 			os.Exit(1)
 		}
 	}


### PR DESCRIPTION
## Description
This PR is to add the validation logic for DBaaSInventory creation/update using a webhook along with CRD validation. The validation checks:
 -- if spec.providerRef.name is provided (by CRD validation)
 -- if spec.crednetialsRef.name is provided (by CRD validation). Spec.crednetialsRef.namespace can be optional and if it is empty, the default (CR's namespace) is used instead.
 -- check if the mandatory fields in the credendialsRef secret are present based on the provider.

Unit test is added. Tested successfully locally.

## Verification Steps
1) Download the attached zip file and extract to a local directory.
[test2.zip](https://github.com/RHEcosystemAppEng/dbaas-operator/files/7365438/test2.zip)
2) Log on to a cluster where DBaaS operator is installed and switch to openshift-dbaas-operator namespace.
3) oc apply -f dbassinventory-missing-provider-name.yaml
The DBaaSInventory "dbaas-jianrzha" is invalid: spec.providerRef: Required value
4) oc apply -f dbassinventory-missing-cred-name.yaml
The DBaaSInventory "dbaas-jianrzha" is invalid: spec.credentialsRef.name: Required value
5) create a secret: 
oc apply -f atlas-key-secret.yaml
secret/my-atlas-key created
5) Create a CR without credentialsRef.namespace. It should use the default namespace (from the CR).
oc apply -f dbassinventory-missing-cred-namespace.yaml
dbaasinventory.dbaas.redhat.com/dbaas-jianrzha created
(note that since dummy credentials are used here, you will see AuthenticationError error in the status, and this is expected).

6) Delete the CR for next test.
oc delete -f dbassinventory.yaml
'dbaasinventory.dbaas.redhat.com "dbaas-jianrzha" deleted

7) Create a secret where orgID is missing:
 oc apply -f  atlas-key-secret-missing-key.yaml 
8) Now creating a CR will cause validation error:
oc apply -f dbassinventory.yaml
Error from server (orgId is required in secret my-atlas-key): error when creating "dbassinventory.yaml": admission webhook "vdbaasinventory.kb.io" denied the request: orgId is required in secret my-atlas-key
9) Now apply a normal secret
oc apply -f atlas-key-secret.yaml
secret/my-atlas-key configured
10) Now we can create a CR successfully(note the secret includes dummy credentials data, so the status of the CR will show error and this is expected)
 oc apply -f dbassinventory.yaml
dbaasinventory.dbaas.redhat.com/dbaas-jianrzha created
11) We will try to test CR update cases.
  oc apply -f dbassinventory-missing-provider-name.yaml
The DBaaSInventory "dbaas-jianrzha" is invalid: spec.providerRef: Required value
jianrzha-mac:test zhangj$ oc apply -f dbassinventory-missing-cred-name.yaml
The DBaaSInventory "dbaas-jianrzha" is invalid: spec.credentialsRef.name: Required value

jianrzha-mac:test zhangj$ oc apply -f dbassinventory-missing-cred-namespace.yaml
dbaasinventory.dbaas.redhat.com/dbaas-jianrzha configured

jianrzha-mac:test zhangj$ oc delete secret/my-atlas-key
secret "my-atlas-key" deleted
jianrzha-mac:test zhangj$ oc apply -f atlas-key-secret-missing-key.yaml
secret/my-atlas-key created
jianrzha-mac:test zhangj$ oc apply -f  dbassinventory.yaml
Error from server (orgId is required in secret my-atlas-key): error when applying patch:
{"metadata":{"annotations":{"kubectl.kubernetes.io/last-applied-configuration":"{\"apiVersion\":\"dbaas.redhat.com/v1alpha1\",\"kind\":\"DBaaSInventory\",\"metadata\":{\"annotations\":{},\"name\":\"dbaas-jianrzha\",\"namespace\":\"openshift-dbaas-operator\"},\"spec\":{\"credentialsRef\":{\"name\":\"my-atlas-key\",\"namespace\":\"openshift-dbaas-operator\"},\"providerRef\":{\"name\":\"mongodb-atlas-registration\"}}}\n"}},"spec":{"credentialsRef":{"namespace":"openshift-dbaas-operator"}}}
to:
Resource: "dbaas.redhat.com/v1alpha1, Resource=dbaasinventories", GroupVersionKind: "dbaas.redhat.com/v1alpha1, Kind=DBaaSInventory"
Name: "dbaas-jianrzha", Namespace: "openshift-dbaas-operator"
for: "dbassinventory.yaml": admission webhook "vdbaasinventory.kb.io" denied the request: orgId is required in secret my-atlas-key

## Type of change
<!-- Please delete options that are not relevant. -->
- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA or in issue number have been completed
- [ ] Unit tests added that prove the fix is effective or the feature works 
- [ ] Documentation added for the feature
- [ ] all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer

An example of errors when creating a provider account without the required fields
![Screen Shot 2021-10-12 at 10 21 51 AM](https://user-images.githubusercontent.com/81316829/136974484-8ba012c4-e6f7-4104-9938-18d0d741cc26.png)
:
