### PR TITLE
adding edit perms for dedicated-admins

### DIFF
--- a/bundle/manifests/dbaas-operator-edit-dedicated-admins_rbac.authorization.k8s.io_v1_rolebinding.yaml
+++ b/bundle/manifests/dbaas-operator-edit-dedicated-admins_rbac.authorization.k8s.io_v1_rolebinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  creationTimestamp: null
+  name: dbaas-operator-edit-dedicated-admins
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: edit
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: dedicated-admins

--- a/config/rbac/dedicated_admin_namespace_edit_role_binding.yaml
+++ b/config/rbac/dedicated_admin_namespace_edit_role_binding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: edit-dedicated-admins
+  namespace: redhat-dbaas-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: edit
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: dedicated-admins

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -12,6 +12,7 @@ resources:
 - dbaasprovider_viewer_role.yaml
 - dbaasprovider_viewer_role_binding.yaml
 - dbaasconnection_viewer_role.yaml
+- dedicated_admin_namespace_edit_role_binding.yaml
 # Comment the following 4 lines if you want to disable
 # the auth proxy (https://github.com/brancz/kube-rbac-proxy)
 # which protects your /metrics endpoint.


### PR DESCRIPTION
(please disregard branch name implying semver bump, we ended up not versioning for this change)

## Description
Adding permissions that will allow avoidance of cluster-admin roles for OSD/ROSA installations