### PR TITLE
DBAAS-201 DBaaS Operator error handling enhancements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ bundle_tmp*
 *.swp
 *.swo
 *~
+.vscode/

--- a/api/v1alpha1/dbaasprovider.go
+++ b/api/v1alpha1/dbaasprovider.go
@@ -21,6 +21,30 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const (
+	// DBaaS condition types
+	DBaaSInventoryReadyType         string = "InventoryReady"
+	DBaaSInventoryProviderSyncType  string = "SpecSynced"
+	DBaaSConnectionProviderSyncType string = "ReadyForBinding"
+	DBaaSConnectionReadyType        string = "ConnectionReady"
+
+	// DBaaS condition reasons
+	Ready                       string = "Ready"
+	DBaaSTenantNotFound         string = "DBaaSTenantNotFound"
+	DBaaSProviderNotFound       string = "DBaaSProviderNotFound"
+	DBaaSInventoryNotFound      string = "DBaaSInventoryNotFound"
+	DBaaSInventoryNotReady      string = "DBaaSInventoryNotReady"
+	ProviderReconcileInprogress string = "ProviderReconcileInprogress"
+	ProviderParsingError        string = "ProviderParsingError"
+
+	// DBaaS condition messages
+	MsgProviderCRStatusSyncDone      string = "Provider Custom Resource status sync completed"
+	MsgProviderCRCreatedOrUpdated    string = "DBaaS Provider Custom Resource created or updated"
+	MsgProviderCRReconcileInProgress string = "DBaaS Provider Custom Resource reconciliation in progress"
+	MsgInventoryNotReady             string = "Inventory discovery not done"
+	MsgTenantNotFound                string = "Failed to find DBaaS tenants"
+)
+
 // DBaaSProviderSpec defines the desired state of DBaaSProvider
 type DBaaSProviderSpec struct {
 	// Provider contains information about database provider & platform

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -31,6 +31,7 @@ spec:
         - /manager
         args:
         - --leader-elect
+        - --log-level=INFO
         image: controller:latest
         name: manager
         imagePullPolicy: Always

--- a/controllers/dbaas_controllers_common_test.go
+++ b/controllers/dbaas_controllers_common_test.go
@@ -25,10 +25,12 @@ import (
 	. "github.com/onsi/gomega"
 
 	"k8s.io/apimachinery/pkg/api/errors"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
@@ -92,6 +94,14 @@ func assertResourceCreation(object client.Object) func() {
 	}
 }
 
+func assertInventoryCreationWithProviderStatus(object client.Object, inventroyDBaaSStatus metav1.ConditionStatus, providerResourceKind string, DBaaSResourceSpec interface{}) func() {
+	return func() {
+		assertResourceCreation(object)()
+		err := dRec.Get(ctx, client.ObjectKeyFromObject(object), object)
+		Expect(err).Should(Succeed())
+		assertDBaaSResourceProviderStatusUpdated(object, inventroyDBaaSStatus, providerResourceKind, DBaaSResourceSpec)()
+	}
+}
 func assertResourceDeletion(object client.Object) func() {
 	return func() {
 		By("deleting resource")
@@ -150,26 +160,42 @@ func assertProviderResourceCreated(object client.Object, providerResourceKind st
 	}
 }
 
-func assertDBaaSResourceStatusUpdated(object client.Object, providerResourceKind string, providerResourceStatus interface{}) func() {
+func assertDBaaSResourceStatusUpdated(object client.Object, status metav1.ConditionStatus, reason string) func() {
 	return func() {
-		By("checking the DBaaS resource status has no conditions")
+		By("checking the DBaaS resource status")
+		objectKey := client.ObjectKeyFromObject(object)
+
+		Eventually(func() (bool, error) {
+			err := dRec.Get(ctx, objectKey, object)
+			if err != nil {
+				return false, err
+			}
+			switch v := object.(type) {
+			case *v1alpha1.DBaaSInventory:
+				dbaasConds, _ := splitStatusConditions(v.Status.Conditions, v1alpha1.DBaaSInventoryReadyType)
+				return len(dbaasConds) > 0 && dbaasConds[0].Status == status && dbaasConds[0].Reason == reason, nil
+			case *v1alpha1.DBaaSConnection:
+				dbaasConds, _ := splitStatusConditions(v.Status.Conditions, v1alpha1.DBaaSConnectionReadyType)
+				return len(dbaasConds) > 0 && dbaasConds[0].Status == status && dbaasConds[0].Reason == reason, nil
+			default:
+				Fail("invalid test object")
+				return false, err
+			}
+		}, duration, interval).Should(BeTrue())
+	}
+}
+
+func assertDBaaSResourceProviderStatusUpdated(object client.Object, inventoryDBaaSStatus metav1.ConditionStatus, providerResourceKind string, providerResourceStatus interface{}) func() {
+	return func() {
+		By("retrieving current DBaaS resource")
 		objectKey := client.ObjectKeyFromObject(object)
 		Consistently(func() (int, error) {
 			err := dRec.Get(ctx, objectKey, object)
 			if err != nil {
 				return -1, err
 			}
-			switch v := object.(type) {
-			case *v1alpha1.DBaaSInventory:
-				return len(v.Status.Conditions), nil
-			case *v1alpha1.DBaaSConnection:
-				return len(v.Status.Conditions), nil
-			default:
-				Fail("invalid test object")
-				return -1, err
-			}
+			return 0, nil
 		}, duration, interval).Should(Equal(0))
-
 		By("getting the provider resource")
 		providerResource := &unstructured.Unstructured{}
 		providerResource.SetGroupVersionKind(schema.GroupVersionKind{
@@ -185,7 +211,6 @@ func assertDBaaSResourceStatusUpdated(object client.Object, providerResourceKind
 				}
 				Expect(err).NotTo(HaveOccurred())
 			}
-
 			By("updating the provider resource status")
 			providerResource.UnstructuredContent()["status"] = providerResourceStatus
 
@@ -199,7 +224,7 @@ func assertDBaaSResourceStatusUpdated(object client.Object, providerResourceKind
 			return true
 		}, timeout, interval).Should(BeTrue())
 
-		By("checking the DBaaS resource status updated")
+		By("checking the DBaaS resource provider status updated")
 		Eventually(func() (int, error) {
 			err := dRec.Get(ctx, objectKey, object)
 			if err != nil {
@@ -207,9 +232,12 @@ func assertDBaaSResourceStatusUpdated(object client.Object, providerResourceKind
 			}
 			switch v := object.(type) {
 			case *v1alpha1.DBaaSInventory:
-				return len(v.Status.Conditions), nil
+				_, conds := splitStatusConditions(v.Status.Conditions, v1alpha1.DBaaSInventoryReadyType)
+				return len(conds), nil
 			case *v1alpha1.DBaaSConnection:
-				return len(v.Status.Conditions), nil
+				assertInventoryDBaaSStatus(v.Spec.InventoryRef.Name, v.Spec.InventoryRef.Namespace, inventoryDBaaSStatus)()
+				_, conds := splitStatusConditions(v.Status.Conditions, v1alpha1.DBaaSConnectionReadyType)
+				return len(conds), nil
 			default:
 				Fail("invalid test object")
 				return -1, err
@@ -217,12 +245,79 @@ func assertDBaaSResourceStatusUpdated(object client.Object, providerResourceKind
 		}, timeout, interval).Should(Equal(1))
 		switch v := object.(type) {
 		case *v1alpha1.DBaaSInventory:
-			Expect(&v.Status).Should(Equal(providerResourceStatus))
+			assertInventoryStatus(v, v1alpha1.DBaaSInventoryReadyType, inventoryDBaaSStatus, providerResourceStatus)()
 		case *v1alpha1.DBaaSConnection:
-			Expect(&v.Status).Should(Equal(providerResourceStatus))
+			assertConnectionStatus(v, v1alpha1.DBaaSConnectionReadyType, providerResourceStatus)()
 		default:
 			Fail("invalid test object")
 		}
+	}
+}
+
+func splitStatusConditions(conds []metav1.Condition, condType string) (dbaasCond []metav1.Condition, providerCond []metav1.Condition) {
+	for _, v := range conds {
+		if v.Type != condType { //skip the DBaaS operator specific condition
+			providerCond = append(providerCond, v)
+		} else {
+			dbaasCond = append(dbaasCond, v)
+		}
+	}
+	return
+}
+
+func assertInventoryDBaaSStatus(name, namespace string, dbaasStatus metav1.ConditionStatus) func() {
+	return func() {
+		updatedInv := &v1alpha1.DBaaSInventory{}
+		Eventually(func() (int, error) {
+			err := dRec.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, updatedInv)
+			if err != nil {
+				return -1, err
+			}
+			cond := apimeta.FindStatusCondition(updatedInv.Status.Conditions, v1alpha1.DBaaSInventoryReadyType)
+			if cond != nil && cond.Status == dbaasStatus {
+				return 0, nil
+			}
+			return 0, nil
+		}, timeout, interval).Should(Equal(0))
+	}
+}
+
+func assertConnectionDBaaSStatus(name, namespace string, dbaasStatus metav1.ConditionStatus) func() {
+	return func() {
+		updatedConn := &v1alpha1.DBaaSConnection{}
+		Eventually(func() (int, error) {
+			err := dRec.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, updatedConn)
+			if err != nil {
+				return -1, err
+			}
+			cond := apimeta.FindStatusCondition(updatedConn.Status.Conditions, v1alpha1.DBaaSConnectionReadyType)
+			if cond != nil && cond.Status == dbaasStatus {
+				return 0, nil
+			}
+			return 0, nil
+		}, timeout, interval).Should(Equal(0))
+	}
+}
+
+func assertInventoryStatus(inv *v1alpha1.DBaaSInventory, condType string, dbaasStatus metav1.ConditionStatus, providerResourceStatus interface{}) func() {
+	return func() {
+		status := inv.Status.DeepCopy()
+		dbaasConds, providerConds := splitStatusConditions(status.Conditions, condType)
+		Expect(len(dbaasConds)).Should(Equal(1))
+		Expect(dbaasConds[0].Type).Should(Equal(condType))
+		Expect(dbaasConds[0].Status).Should(Equal(dbaasStatus))
+		status.Conditions = providerConds
+		Expect(status).Should(Equal(providerResourceStatus))
+	}
+}
+
+func assertConnectionStatus(conn *v1alpha1.DBaaSConnection, condType string, providerResourceStatus interface{}) func() {
+	return func() {
+		assertConnectionDBaaSStatus(conn.Name, conn.Namespace, metav1.ConditionTrue)()
+		status := conn.Status.DeepCopy()
+		_, providerConds := splitStatusConditions(status.Conditions, condType)
+		status.Conditions = providerConds
+		Expect(status).Should(Equal(providerResourceStatus))
 	}
 }
 

--- a/controllers/dbaas_reconciler.go
+++ b/controllers/dbaas_reconciler.go
@@ -99,13 +99,6 @@ func (p *DBaaSReconciler) parseProviderObject(unstructured *unstructured.Unstruc
 	return nil
 }
 
-func (p *DBaaSReconciler) reconcileDBaaSObjectStatus(object client.Object, f controllerutil.MutateFn, ctx context.Context) error {
-	if err := f(); err != nil {
-		return err
-	}
-	return p.Status().Update(ctx, object)
-}
-
 func (r *DBaaSReconciler) createOwnedObject(k8sObj, owner client.Object, ctx context.Context) error {
 	if err := ctrl.SetControllerReference(owner, k8sObj, r.Scheme); err != nil {
 		return err

--- a/controllers/dbaasinventory_controller.go
+++ b/controllers/dbaasinventory_controller.go
@@ -21,6 +21,8 @@ import (
 
 	"github.com/RHEcosystemAppEng/dbaas-operator/api/v1alpha1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 )
@@ -39,74 +41,96 @@ type DBaaSInventoryReconciler struct {
 //
 // For more details, check Reconcile and its Result here:
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.8.3/pkg/reconcile
-func (r *DBaaSInventoryReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+func (r *DBaaSInventoryReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, recErr error) {
 	logger := ctrl.LoggerFrom(ctx, "DBaaS Inventory", req.NamespacedName)
+	var inventory v1alpha1.DBaaSInventory
+	if err := r.Get(ctx, req.NamespacedName, &inventory); err != nil {
+		if errors.IsNotFound(err) {
+			// CR deleted since request queued, child objects getting GC'd, no requeue
+			logger.V(1).Info("DBaaS Inventory resource not found, has been deleted")
+			result, recErr = ctrl.Result{}, nil
+			return
+		}
+		logger.Error(err, "Error fetching DBaaS Inventory for reconcile")
+		result, recErr = ctrl.Result{}, err
+		return
+	}
+
+	var dbaasCond metav1.Condition
+	// This update will make sure the status is always updated in case of any errors or successful result
+	defer func(inv *v1alpha1.DBaaSInventory, cond *metav1.Condition) {
+		apimeta.SetStatusCondition(&inv.Status.Conditions, *cond)
+		if err := r.Client.Status().Update(ctx, inv); err != nil {
+			if errors.IsConflict(err) {
+				logger.V(1).Info("Inventory modified, retry syncing spec")
+				// Re-queue and preserve existing recErr
+				result = ctrl.Result{Requeue: true}
+				return
+			}
+			logger.Error(err, "Could not update inventory status")
+			if recErr == nil {
+				// There is no existing recErr. Set it to the status update error
+				recErr = err
+			}
+		}
+	}(&inventory, &dbaasCond)
 
 	tenantList, err := r.tenantListByInventoryNS(ctx, req.Namespace)
 	if err != nil {
 		logger.Error(err, "unable to list tenants")
-		return ctrl.Result{}, err
+		result, recErr = ctrl.Result{}, err
+		return
 	}
 
-	// continue only if the request is in a valid tenant namespace
-	if len(tenantList.Items) > 0 {
-		var inventory v1alpha1.DBaaSInventory
-		if err := r.Get(ctx, req.NamespacedName, &inventory); err != nil {
-			if errors.IsNotFound(err) {
-				// CR deleted since request queued, child objects getting GC'd, no requeue
-				return ctrl.Result{}, nil
-			}
-			logger.Error(err, "Error fetching DBaaS Inventory for reconcile")
-			return ctrl.Result{}, err
-		}
-
-		//
-		// Provider Inventory
-		//
-		provider, err := r.getDBaaSProvider(inventory.Spec.ProviderRef.Name, ctx)
-		if err != nil {
-			if errors.IsNotFound(err) {
-				logger.Error(err, "Requested DBaaS Provider is not configured in this environment", "DBaaS Provider", inventory.Spec.ProviderRef)
-				return ctrl.Result{}, err
-			}
-			logger.Error(err, "Error reading configured DBaaS Provider", "DBaaS Provider", inventory.Spec.ProviderRef)
-			return ctrl.Result{}, err
-		}
-		logger.V(1).Info("Found DBaaS Provider", "DBaaS Provider", inventory.Spec.ProviderRef)
-
-		providerInventory := r.createProviderObject(&inventory, provider.Spec.InventoryKind)
-		if result, err := r.reconcileProviderObject(providerInventory, r.providerObjectMutateFn(&inventory, providerInventory, inventory.Spec.DeepCopy()), ctx); err != nil {
-			if errors.IsConflict(err) {
-				logger.V(1).Info("Provider Inventory modified, retry syncing spec")
-				return ctrl.Result{Requeue: true}, nil
-			}
-			logger.Error(err, "Error reconciling the Provider Inventory resource")
-			return ctrl.Result{}, err
-		} else {
-			logger.V(1).Info("Provider Inventory resource reconciled", "result", result)
-		}
-
-		var DBaaSProviderInventory v1alpha1.DBaaSProviderInventory
-		if err := r.parseProviderObject(providerInventory, &DBaaSProviderInventory); err != nil {
-			logger.Error(err, "Error parsing the Provider Inventory resource")
-			return ctrl.Result{}, err
-		}
-		if err := r.reconcileDBaaSObjectStatus(&inventory, func() error {
-			DBaaSProviderInventory.Status.DeepCopyInto(&inventory.Status)
-			return nil
-		}, ctx); err != nil {
-			if errors.IsConflict(err) {
-				logger.V(1).Info("DBaaS Inventory modified, retry syncing status")
-				return ctrl.Result{Requeue: true}, nil
-			}
-			logger.Error(err, "Error updating the DBaaS Inventory status")
-			return ctrl.Result{}, err
-		} else {
-			logger.V(1).Info("DBaaS Inventory status updated")
-		}
+	if len(tenantList.Items) == 0 {
+		logger.Info("No DBaaS tenant found for the target namespace", "Namespace", req.Namespace)
+		dbaasCond = metav1.Condition{Type: v1alpha1.DBaaSInventoryReadyType, Status: metav1.ConditionFalse, Reason: v1alpha1.DBaaSTenantNotFound, Message: v1alpha1.MsgTenantNotFound}
+		result, recErr = ctrl.Result{}, nil
+		return
 	}
 
-	return ctrl.Result{}, nil
+	//
+	// Provider Inventory
+	//
+	provider, err := r.getDBaaSProvider(inventory.Spec.ProviderRef.Name, ctx)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			logger.Error(err, "Requested DBaaS Provider is not configured in this environment", "DBaaS Provider", inventory.Spec.ProviderRef)
+			dbaasCond = metav1.Condition{Type: v1alpha1.DBaaSInventoryReadyType, Status: metav1.ConditionFalse, Reason: v1alpha1.DBaaSProviderNotFound, Message: err.Error()}
+			result, recErr = ctrl.Result{}, err
+			return
+		}
+		logger.Error(err, "Error reading configured DBaaS Provider", "DBaaS Provider", inventory.Spec.ProviderRef)
+		result, recErr = ctrl.Result{}, err
+		return
+	}
+	logger.V(1).Info("Found DBaaS Provider", "DBaaS Provider", inventory.Spec.ProviderRef)
+
+	providerInventory := r.createProviderObject(&inventory, provider.Spec.InventoryKind)
+	if res, err := r.reconcileProviderObject(providerInventory, r.providerObjectMutateFn(&inventory, providerInventory, inventory.Spec.DeepCopy()), ctx); err != nil {
+		if errors.IsConflict(err) {
+			logger.V(1).Info("Provider Inventory modified, retry syncing spec")
+			result, recErr = ctrl.Result{Requeue: true}, nil
+			return
+		}
+		logger.Error(err, "Error reconciling the Provider Inventory resource")
+		result, recErr = ctrl.Result{}, err
+		return
+	} else {
+		logger.V(1).Info("Provider Inventory resource reconciled", "result", res)
+	}
+
+	var DBaaSProviderInventory v1alpha1.DBaaSProviderInventory
+	if err := r.parseProviderObject(providerInventory, &DBaaSProviderInventory); err != nil {
+		logger.Error(err, "Error parsing the Provider Inventory resource")
+		dbaasCond = metav1.Condition{Type: v1alpha1.DBaaSInventoryReadyType, Status: metav1.ConditionFalse, Reason: v1alpha1.ProviderParsingError, Message: err.Error()}
+		result, recErr = ctrl.Result{}, err
+		return
+	}
+
+	dbaasCond = *mergeInventoryStatus(&inventory, &DBaaSProviderInventory)
+	result, recErr = ctrl.Result{}, nil
+	return
 }
 
 // SetupWithManager sets up the controller with the Manager.
@@ -114,4 +138,19 @@ func (r *DBaaSInventoryReconciler) SetupWithManager(mgr ctrl.Manager) (controlle
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&v1alpha1.DBaaSInventory{}).
 		Build(r)
+}
+
+// mergeInventoryStatus: merge the status from DBaaSProviderInventory into the current DBaaSInventory status
+func mergeInventoryStatus(inv *v1alpha1.DBaaSInventory, providerInv *v1alpha1.DBaaSProviderInventory) *metav1.Condition {
+	cond := apimeta.FindStatusCondition(inv.Status.Conditions, v1alpha1.DBaaSInventoryReadyType)
+	providerInv.Status.DeepCopyInto(&inv.Status)
+	if cond != nil {
+		inv.Status.Conditions = append(inv.Status.Conditions, *cond)
+	}
+	// Update inventory status condition (type: DBaaSInventoryReadyType) based on the provider status
+	specSync := apimeta.FindStatusCondition(providerInv.Status.Conditions, v1alpha1.DBaaSInventoryProviderSyncType)
+	if cond != nil && specSync != nil && specSync.Status == metav1.ConditionTrue {
+		return &metav1.Condition{Type: v1alpha1.DBaaSInventoryReadyType, Status: metav1.ConditionTrue, Reason: v1alpha1.Ready, Message: v1alpha1.MsgProviderCRStatusSyncDone}
+	}
+	return &metav1.Condition{Type: v1alpha1.DBaaSInventoryReadyType, Status: metav1.ConditionFalse, Reason: v1alpha1.ProviderReconcileInprogress, Message: v1alpha1.MsgProviderCRReconcileInProgress}
 }

--- a/controllers/dbaasplatform_controller.go
+++ b/controllers/dbaasplatform_controller.go
@@ -238,10 +238,11 @@ func (r *DBaaSPlatformReconciler) createPlatformCR(ctx context.Context, serverCl
 func (r *DBaaSPlatformReconciler) getInstallationPlatforms() []dbaasv1alpha1.PlatformsName {
 
 	return []dbaasv1alpha1.PlatformsName{
-		dbaasv1alpha1.CrunchyBridgeInstallation,
-		dbaasv1alpha1.MongoDBAtlasInstallation,
+		//Deploy Dynamic plugin and Console Telemetry Plugin before provider operators
 		dbaasv1alpha1.DBaaSDynamicPluginInstallation,
 		dbaasv1alpha1.ConsoleTelemetryPluginInstallation,
+		dbaasv1alpha1.CrunchyBridgeInstallation,
+		dbaasv1alpha1.MongoDBAtlasInstallation,
 		dbaasv1alpha1.ServiceBindingInstallation,
 		dbaasv1alpha1.Csv,
 	}

--- a/controllers/dbaasprovider_controller_test.go
+++ b/controllers/dbaasprovider_controller_test.go
@@ -93,8 +93,8 @@ var _ = Describe("DBaaSProvider controller", func() {
 				updatedProvider.Spec.InventoryKind = "CrunchyBridgeInventory"
 				updatedProvider.Spec.ConnectionKind = "CrunchyBridgeConnection"
 				Expect(dRec.Update(ctx, updatedProvider)).Should(Succeed())
-				pProvider := &v1alpha1.DBaaSProvider{}
 				Eventually(func() v1alpha1.DBaaSProviderSpec {
+					pProvider := &v1alpha1.DBaaSProvider{}
 					err := dRec.Get(ctx, client.ObjectKeyFromObject(updatedProvider), pProvider)
 					if err != nil {
 						return v1alpha1.DBaaSProviderSpec{}

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -55,7 +55,7 @@ const (
 
 	timeout  = time.Second * 60
 	duration = time.Second * 10
-	interval = time.Millisecond * 250
+	interval = time.Millisecond * 500
 )
 
 func TestControllers(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/openshift/api v0.0.0-20210910062324-a41d3573a3ba
 	github.com/openshift/client-go v0.0.0-20200320143156-e7fa42a1261e
 	github.com/operator-framework/api v0.10.5
+	go.uber.org/zap v1.17.0 // indirect
 	k8s.io/api v0.21.1
 	k8s.io/apimachinery v0.21.1
 	k8s.io/client-go v0.21.1

--- a/main.go
+++ b/main.go
@@ -22,6 +22,7 @@ import (
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
+	"go.uber.org/zap/zapcore"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
 	oauthzv1 "github.com/openshift/api/authorization/v1"
@@ -66,13 +67,23 @@ func main() {
 	var metricsAddr string
 	var enableLeaderElection bool
 	var probeAddr string
+	var logLevel string
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
+	flag.StringVar(&logLevel, "log-level", "info", "Log level.")
+
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
+
+	var level zapcore.Level
+	if err := level.UnmarshalText([]byte(logLevel)); err != nil {
+		//default to info level
+		level = zapcore.InfoLevel
+	}
 	opts := zap.Options{
 		Development: true,
+		Level:       level,
 	}
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()


### PR DESCRIPTION
## Description
This PR is to implement https://issues.redhat.com/browse/DBAAS-201 and enhance the reconciliation logic so that the operator sets the appropriate status for the DBaaSConnection and DBaaSInventory CRs. Typical cases include:
1) There is no tenant configured for the DBaaSInventory CR in the namespace
2) There is no valid provider found for the DBaaSInventory CR
3) The inventory for the DBaaSConnection CR does not exist
4) The provider of the inventory for the DBaaSConnection CR is not valid
 5) The inventory for the DBaaSConnection CR is not ready, ie, service discovery has not been completed successfully

In this PR, a new "Ready" condition type is added to DBaaSInventory and DBaaSConnection status conditions along with existing conditions synced from provider operators.

There are two changes to the reconciliation flows:
1) For DBaaSConnection:  check if the inventory is ready before further reconciliation (creating provider CR etc) is performed;
2) For DBaaSInvetory:  the function to retrieve the inventory was moved in front of the dbaastenant checking. This allows us to set a corresponding status condition in the CR in case there is no tenant configured for the target namespace.

## Verification Steps
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.
-->

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] All acceptance criteria specified in JIRA or in issue number have been completed
- [x] Unit tests added that prove the fix is effective or the feature works 
- [ ] Documentation added for the feature
- [x] all relevant tests are passing
- [x] Code Review completed
- [x] Verified independently by reviewer

Verification steps:
1) Create an OpenShift 4.9 RHDMS testing cluster and deploy the DBaaS Operator under openshift-dbaas-operator project.
2) Download attached zip file and unzip.
[error-handling-test.zip](https://github.com/RHEcosystemAppEng/dbaas-operator/files/7612534/error-handling-test.zip)
3) log in to the cluster as cluster admin.
4) oc new-project jianrong
Note: The default dbaas tenant is only configured for openshift-dbaas-operator
5) Create an inventory that does not have a provider registered: 
oc apply -f dbassinventory-notenant.yaml
dbaasinventory.dbaas.redhat.com/dbaas-jianrzha-notenant created
Check the created CR status. Example:
Status:
  Conditions:
    Last Transition Time:  2021-11-24T02:12:38Z
    Message:               failed to find DBaaS tenants
    Reason:                DBaaSTenantNotFound
    Status:                False
    Type:                  Ready
6) Now create a connection with above inventory:
 oc apply -f dbassconnection_notenant.yaml
dbaasconnection.dbaas.redhat.com/test-dbaas-connection-notenant created
Status:
  Conditions:
    Last Transition Time:  2021-11-26T01:38:47Z
    Message:               Inventory discovery not done
    Reason:                DBaaSInventoryNotReady
    Status:                False
    Type:                  Ready

7) Now switch to openshift-dbaas-operator where the default tenant is applied.
oc project openshift-dbaas-operator
8) oc apply -f dbassinventory_noprovider.yaml
dbaasinventory.dbaas.redhat.com/dbaas-jianrzha-no-provider created
Check the created CR status. Example:
Status:
  Conditions:
    Last Transition Time:  2021-11-24T02:15:41Z
    Message:               DBaaSProvider.dbaas.redhat.com "mongodb-atlas-registration-nonexist" not found
    Reason:                DBaaSProviderNotFound
    Status:                False
    Type:                  Ready
9) Now create a connection with previous connection:
oc apply -f dbassconnection_noprovider.yaml
dbaasconnection.dbaas.redhat.com/test-dbaas-connection-no-provider created
Check CR status:
Status:
  Conditions:
    Last Transition Time:  2021-11-26T01:41:50Z
    Message:               DBaaSProvider.dbaas.redhat.com "mongodb-atlas-registration-nonexist" not found
    Reason:                DBaaSProviderNotFound
    Status:                False
    Type:                  Ready

10) oc apply -f dbassinventory.yaml
dbaasinventory.dbaas.redhat.com/dbaas-jianrzha created
Check inventory CR status - note that its status is False.
Status:
  Conditions:
    Last Transition Time:  2021-11-26T02:01:29Z
    Message:               Secret "my-atlas-key" not found
    Reason:                InputError
    Status:                False
    Type:                  SpecSynced
    Last Transition Time:  2021-11-26T02:01:29Z
    Message:               DBaaS Provider Custom Resource created or updated
    Reason:                ProviderReconcileInprogress
    Status:                False
    Type:                  Ready
11) Now create a connection:
 oc apply -f dbassconnection.yaml
dbaasconnection.dbaas.redhat.com/test-dbaas-connection created
Check the connection status:
Status:
  Conditions:
    Last Transition Time:  2021-11-26T02:03:03Z
    Message:               Inventory discovery not done
    Reason:                DBaaSInventoryNotReady
    Status:                False
    Type:                  Ready
12) Create a file atlas-key.yaml as follows
apiVersion: v1
kind: Secret
metadata:
  name: my-atlas-key
type: Opaque
data:
  orgId: <your orgId>
  privateApiKey: <Your private API Key for Atlas>
  publicApiKey: <Your public API Key for Atlas>
13) Create the secret:
oc apply -f <Your private API Key>
Now check the above inventory status:
Status:
  Conditions:
    Last Transition Time:  2021-11-26T02:01:29Z
    Message:               GET https://cloud.mongodb.com/api/atlas/v1.0/groups: 403 (request "IP_ADDRESS_NOT_ON_ACCESS_LIST") IP address 18.189.136.122 is not allowed to access this resource.
    Reason:                BackendError
    Status:                False
    Type:                  SpecSynced
    Last Transition Time:  2021-11-26T02:01:29Z
    Message:               DBaaS Provider Custom Resource created or updated
    Reason:                ProviderReconcileInprogress
    Status:                False
    Type:                  Ready
and check the above connections sttaus:
Status:
  Conditions:
    Last Transition Time:  2021-11-26T02:03:03Z
    Message:               Inventory discovery not done
    Reason:                DBaaSInventoryNotReady
    Status:                False
    Type:                  Ready

15) Now we add the IP address (18.189.136.122 herein) into the IP access list in Atlas website.
Check the inventory status again - now you can see that the inventory has been successfully reconciled:
Status:
  Conditions:
    Last Transition Time:  2021-11-26T02:08:51Z
    Message:               Spec sync OK
    Reason:                SyncOK
    Status:                True
    Type:                  SpecSynced
    Last Transition Time:  2021-11-26T02:08:51Z
    Message:               Provider Custom Resource status sync completed
    Reason:                Ready
    Status:                True
    Type:                  Ready
  Instances:
    Instance ID:  608df625aa94426b4167e45f
    Instance Info:
      Connection Strings Standard Srv:  mongodb+srv://dbaas-cluster1.h38mo.mongodb.net
      Instance Size Name:               M0
      Project ID:                       608df5e652e1944293e8584a
      Project Name:                     Project 1
      Provider Name:                    TENANT
      Region Name:                      US_EAST_1
    Name:                               DBaaS-Cluster1
    Instance ID:                        60807282b4ab8d3b3c84be53
    Instance Info:
      Connection Strings Standard Srv:  mongodb+srv://test.iojsa.mongodb.net
      Instance Size Name:               M10
      Project ID:                       6065e15b16c0731bf3a2aefa
      Project Name:                     Project 2
      Provider Name:                    AWS
      Region Name:                      US_EAST_1
    Name:                               test
    Instance ID:                        606b2ffbc9a90e310e642482
    Instance Info:
      Connection Strings Standard Srv:  mongodb+srv://dbcreatedinatalas.iojsa.mongodb.net
      Instance Size Name:               M0
      Project ID:                       6065e15b16c0731bf3a2aefa
      Project Name:                     Project 2
      Provider Name:                    TENANT
      Region Name:                      US_EAST_1
    Name:                               DBCreatedInAtalas
    Instance ID:                        60b7a72f4877d05880c487d2
    Instance Info:
      Connection Strings Standard Srv:  mongodb+srv://test.fbbz5.mongodb.net
      Instance Size Name:               M10
      Project ID:                       60b798fea37f9f09acc1a154
      Project Name:                     jianrzha
      Provider Name:                    AWS
      Region Name:                      US_EAST_1
    Name:                               test

Now lets check the connection CR status:
status:
  conditions:
  - lastTransitionTime: "2021-11-26T02:11:15Z"
    message: ""
    reason: Ready
    status: "True"
    type: ReadyForBinding
  - lastTransitionTime: "2021-11-26T02:49:49Z"
    message: Provider Custom Resource status sync completed
    reason: Ready
    status: "True"
    type: Ready
  connectionInfoRef:
    name: atlas-connection-cm-c9f67
  credentialsRef:
    name: atlas-db-user-rhjjf


