### PR TITLE
Remove DBAAS_CSV from constants.go

### DIFF
--- a/controllers/reconcilers/constants.go
+++ b/controllers/reconcilers/constants.go
@@ -17,5 +17,4 @@ const (
 	MONGODB_ATLAS_CSV                        = "mongodb-atlas-kubernetes.v0.1.0"
 	CRUNCHY_BRIDGE_CSV                       = "crunchy-bridge-operator.v0.0.2-dev"
 	SERVICE_BINDING_CSV                      = "service-binding-operator.v0.10.0"
-	DBAAS_CSV                                = "dbaas-operator.v0.1.3"
 )

--- a/controllers/reconcilers/csv.go
+++ b/controllers/reconcilers/csv.go
@@ -42,10 +42,10 @@ func CheckOwnerReferenceSet(cr *alpha1.DBaaSPlatform, csv *v1alpha1.ClusterServi
 	return equal, nil
 }
 
-func GetDBaaSOperatorCSV(namespace string, ctx context.Context, serverClient k8sclient.Client) (*v1alpha1.ClusterServiceVersion, error) {
+func GetDBaaSOperatorCSV(namespace string, name string, ctx context.Context, serverClient k8sclient.Client) (*v1alpha1.ClusterServiceVersion, error) {
 	csv := &v1alpha1.ClusterServiceVersion{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      DBAAS_CSV,
+			Name:      name,
 			Namespace: namespace,
 		},
 	}


### PR DESCRIPTION
## Description
This PR is to remove the variable DBAAS_CSV from constants.go because the information is already provided by the environment variable  OPERATOR_CONDITION_NAME in the dbaas operator pod. This fix also allows developers to do the dbaas operator local build without manually modifying the Makefile and constants.go file (by setting the environment variables before the build).

## Verification Steps
Do a local build with a version 0.4.1-dev different from 0.1.3, and then deploy the operator in a clean cluster.

Prior to this fix, the deployment would fail with error like:
https://github.com/RHEcosystemAppEng/dbaas-operator/blob/main/controllers/reconcilers/constants.go#L20
I got deployment error
ERROR	setup	unable to create controller	{"controller": "DBaaSPlatform", "error": "could not create dbaas platform intallation CR: clusterserviceversions.operators.coreos.com \"dbaas-operator.v0.1.3\" not found"}
main.main
	/workspace/main.go:173
runtime.main
	/usr/local/go/src/runtime/proc.go:225

With this fix, the deployment should be successful.
## Type of change
<!-- Please delete options that are not relevant. -->
- [ X] Bug fix (non-breaking change which fixes an issue)

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA or in issue number have been completed
- [ ] Unit tests added that prove the fix is effective or the feature works 
- [ ] Documentation added for the feature
- [ X] all relevant tests are passing
- [ X] Code Review completed
- [ ] Verified independently by reviewer