### PR TITLE
added CONTAINER_ENGINE option in makefile to support podman build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,9 @@
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
 VERSION ?= 0.1.4
 
+
+CONTAINER_ENGINE?=docker
+
 # OLD_BUNDLE_VERSIONS defines the comma separated list of versions of old bundles to add to the index.
 #
 # This is NOT required if you are incrementally building the catalog index. If you need to increment on
@@ -130,10 +133,10 @@ run: manifests generate fmt vet ## Run a controller from your host.
 	go run ./main.go
 
 docker-build: test ## Build docker image with the manager.
-	docker build -t ${IMG} .
+	$(CONTAINER_ENGINE) build -t ${IMG} .
 
 docker-push: ## Push docker image with the manager.
-	docker push ${IMG}
+	$(CONTAINER_ENGINE) push ${IMG}
 
 ##@ Deployment
 
@@ -215,7 +218,7 @@ bundle: manifests kustomize ## Generate bundle manifests and metadata, then vali
 
 .PHONY: bundle-build
 bundle-build: ## Build the bundle image.
-	docker build -f bundle.Dockerfile -t $(BUNDLE_IMG) .
+	$(CONTAINER_ENGINE) build -f bundle.Dockerfile -t $(BUNDLE_IMG) .
 
 .PHONY: bundle-push
 bundle-push: ## Push the bundle image.
@@ -259,7 +262,7 @@ endif
 # https://github.com/operator-framework/community-operators/blob/7f1438c/docs/packaging-operator.md#updating-your-existing-operator
 .PHONY: catalog-build
 catalog-build: opm ## Build a catalog image.
-	$(OPM) index add --container-tool docker --mode semver --tag $(CATALOG_IMG) --bundles $(BUNDLE_IMGS) $(FROM_INDEX_OPT)
+	$(OPM) index add --container-tool $(CONTAINER_ENGINE) --mode semver --tag $(CATALOG_IMG) --bundles $(BUNDLE_IMGS) $(FROM_INDEX_OPT)
 
 # Push the catalog image.
 .PHONY: catalog-push

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Service Binding Operator|[Service Binding Operator](https://github.com/redhat-de
 
 ## Building the Operator
 Build the Red Hat OpenShift Database Access Operator image and push it to a public registry, such as quay.io:
+
+**if you are using podman instead of docker set CONTAINER_ENGINE as podman** `export CONTAINER_ENGINE=podman`
 - `make build`
 - `make docker-build docker-push IMG=quay.io/<YOUR_USERNAME_IN_QUAY>/dbaas-operator:<version>`
 


### PR DESCRIPTION
currently makefile support build with docker, added configurable variable into CONTAINER_ENGINE to support podman build. if anyone using podman instead of docker need to set CONTAINER_ENGINE as podman** `export CONTAINER_ENGINE=podman`

## Description
<!-- Please include a summary of the change and link to the related Jira issue. Please add any additional motivation and context as needed. Screenshots are also welcome -->

## Verification Steps
verify by running command `make release-build` and make sure it's working as expected. 
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.
-->

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA or in issue number have been completed
- [ ] Unit tests added that prove the fix is effective or the feature works 
- [ ] Documentation added for the feature
- [ ] all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer