### PR TITLE
Remove default value for CATALOG_BASE_IMG

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,9 +24,6 @@ CATALOG_VERSION ?= 0.1
 # CHANGE THIS TO YOUR OWN QUAY USERNAME FOR DEV/TESTING/PUSHING
 QUAY_ORG ?= ecosystem-appeng
 
-# CATALOG_BASE_IMG defines an existing catalog version to build on & add bundles to
-CATALOG_BASE_IMG ?= quay.io/$(QUAY_ORG)/dbaas-operator-catalog:v$(CATALOG_VERSION)
-
 export OPERATOR_CONDITION_NAME=dbaas-operator.v$(VERSION)
 
 # CHANNELS define the bundle channels used in the bundle.


### PR DESCRIPTION
When a user run `make catalog-build` for the first time, it produce
error due to missing catalog base image.

For continuous delivery, this variable can be bet set outside Makefile.

## Description
<!-- Please include a summary of the change and link to the related Jira issue. Please add any additional motivation and context as needed. Screenshots are also welcome -->

## Verification Steps
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.
-->

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA or in issue number have been completed
- [ ] Unit tests added that prove the fix is effective or the feature works 
- [ ] Documentation added for the feature
- [ ] all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer