### PR TITLE
allow each console plugin to have its own cert secret instead of sharing one name

### DIFF
--- a/controllers/reconcilers/console_plugin/plugin_installation_reconciler.go
+++ b/controllers/reconcilers/console_plugin/plugin_installation_reconciler.go
@@ -24,8 +24,8 @@ import (
 )
 
 const (
-	consoleServingCertSecretName = "console-serving-cert"
-	consolePort                  = 9001
+	serviceCertPrefix = "serve-cert-"
+	consolePort       = 9001
 )
 
 type Reconciler struct {
@@ -107,7 +107,7 @@ func (r *Reconciler) reconcileService(cr *v1alpha1.DBaaSPlatform, ctx context.Co
 			return err
 		}
 		service.Annotations = map[string]string{
-			"service.beta.openshift.io/serving-cert-secret-name": consoleServingCertSecretName,
+			"service.beta.openshift.io/serving-cert-secret-name": serviceCertPrefix + r.config.Name,
 		}
 		service.Labels = map[string]string{
 			"app":                         r.config.Name,
@@ -190,7 +190,7 @@ func (r *Reconciler) reconcileDeployment(cr *v1alpha1.DBaaSPlatform, ctx context
 				},
 				VolumeMounts: []v1.VolumeMount{
 					{
-						Name:      consoleServingCertSecretName,
+						Name:      serviceCertPrefix + r.config.Name,
 						ReadOnly:  true,
 						MountPath: "/var/serving-cert",
 					},
@@ -218,10 +218,10 @@ func (r *Reconciler) reconcileDeployment(cr *v1alpha1.DBaaSPlatform, ctx context
 		}
 		deployment.Spec.Template.Spec.Volumes = []v1.Volume{
 			{
-				Name: consoleServingCertSecretName,
+				Name: serviceCertPrefix + r.config.Name,
 				VolumeSource: v1.VolumeSource{
 					Secret: &v1.SecretVolumeSource{
-						SecretName:  consoleServingCertSecretName,
+						SecretName:  serviceCertPrefix + r.config.Name,
 						DefaultMode: &defaultMode,
 					},
 				},


### PR DESCRIPTION
currently, `console-serving-cert` is used to specify a secret where openshift cert generation should store the route/service's TLS cert/key. Since we're using the same name in the annotation for both of our plugin services, we're causing an ownership issue.

```
Error while loading plugin from /api/plugins/dbaas-dynamic-plugin/ r: GET request for "dbaas-dynamic-plugin" plugin failed: Get "https://dbaas-dynamic-plugin.openshift-dbaas-operator.svc.cluster.local:9001/plugin-manifest.json": x509: certificate is valid for console-telemetry-plugin.openshift-dbaas-operator.svc, console-telemetry-plugin.openshift-dbaas-operator.svc.cluster.local, not dbaas-dynamic-plugin.openshift-dbaas-operator.svc.cluster.local
```
![image](https://user-images.githubusercontent.com/1012188/154600519-21345687-101d-42ab-a301-ed84c7d04a06.png)

