### PR TITLE
DBAAS-379: Add webhook for dbaastenant to only allow one tenant object per inventory namespace

### DIFF
--- a/PROJECT
+++ b/PROJECT
@@ -47,6 +47,9 @@ resources:
   kind: DBaaSTenant
   path: github.com/RHEcosystemAppEng/dbaas-operator/api/v1alpha1
   version: v1alpha1
+  webhooks:
+    validation: true
+    webhookVersion: v1
 - api:
     crdVersion: v1
     namespaced: true

--- a/api/v1alpha1/dbaastenant_webhook.go
+++ b/api/v1alpha1/dbaastenant_webhook.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2022.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+)
+
+// log is for logging in this package.
+var dbaastenantlog = logf.Log.WithName("dbaastenant-resource")
+
+const inventoryNamespaceKey = ".spec.inventoryNamespace"
+
+var tenantWebhookApiClient client.Client
+
+func (r *DBaaSTenant) SetupWebhookWithManager(mgr ctrl.Manager) error {
+	if tenantWebhookApiClient == nil {
+		tenantWebhookApiClient = mgr.GetClient()
+	}
+	return ctrl.NewWebhookManagedBy(mgr).
+		For(r).
+		Complete()
+}
+
+//+kubebuilder:webhook:path=/validate-dbaas-redhat-com-v1alpha1-dbaastenant,mutating=false,failurePolicy=fail,sideEffects=None,groups=dbaas.redhat.com,resources=dbaastenants,verbs=create;update,versions=v1alpha1,name=vdbaastenant.kb.io,admissionReviewVersions=v1
+
+var _ webhook.Validator = &DBaaSTenant{}
+
+// ValidateCreate implements webhook.Validator so a webhook will be registered for the type
+func (r *DBaaSTenant) ValidateCreate() error {
+	dbaastenantlog.Info("validate create", "name", r.Name)
+	return r.validateTenant()
+}
+
+// ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
+func (r *DBaaSTenant) ValidateUpdate(old runtime.Object) error {
+	dbaastenantlog.Info("validate update", "name", r.Name)
+	return r.validateTenant()
+}
+
+// ValidateDelete implements webhook.Validator so a webhook will be registered for the type
+func (r *DBaaSTenant) ValidateDelete() error {
+	dbaastenantlog.Info("validate delete", "name", r.Name)
+	return nil
+}
+
+func (r *DBaaSTenant) validateTenant() error {
+	tenantsList := &DBaaSTenantList{}
+	if err := tenantWebhookApiClient.List(context.TODO(), tenantsList, client.MatchingFields{inventoryNamespaceKey: r.Spec.InventoryNamespace}); err != nil {
+		return err
+	}
+
+	if len(tenantsList.Items) > 0 {
+		errMsg := fmt.Sprintf("the namespace %s is already managed by tenant %s, it cannot be managed by another tenant", r.Spec.InventoryNamespace, tenantsList.Items[0].Name)
+		return field.Invalid(field.NewPath("spec").Child("inventoryNamespace"), r.Spec.InventoryNamespace, errMsg)
+	}
+
+	return nil
+}

--- a/api/v1alpha1/dbaastenant_webhook_test.go
+++ b/api/v1alpha1/dbaastenant_webhook_test.go
@@ -1,0 +1,85 @@
+/*
+Copyright 2022.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var tenantName = "test-tenant"
+var namespaceName = "test-namespace"
+var testDBaaSTenant = &DBaaSTenant{
+	ObjectMeta: metav1.ObjectMeta{
+		Name: tenantName,
+	},
+	Spec: DBaaSTenantSpec{
+		InventoryNamespace: namespaceName,
+	},
+}
+
+var _ = Describe("DBaaSTenant Webhook", func() {
+	Context("after creating DBaaSTenant", func() {
+		BeforeEach(func() {
+			By("creating DBaaSTenant")
+			Expect(k8sClient.Create(ctx, testDBaaSTenant)).Should(Succeed())
+
+			By("checking DBaaSTenant created")
+			Eventually(func() bool {
+				if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(testDBaaSTenant), &DBaaSTenant{}); err != nil {
+					return false
+				}
+				return true
+			}, timeout, interval).Should(BeTrue())
+		})
+
+		AfterEach(func() {
+			By("deleting DBaaSTenant")
+			Expect(k8sClient.Delete(ctx, testDBaaSTenant)).Should(Succeed())
+
+			By("checking DBaaSTenant deleted")
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, client.ObjectKeyFromObject(testDBaaSTenant), &DBaaSTenant{})
+				if err != nil && errors.IsNotFound(err) {
+					return true
+				}
+				return false
+			}, timeout, interval).Should(BeTrue())
+		})
+
+		Context("after creating DBaaSTenant of the same inventory namespace", func() {
+			It("should not allow creating DBaaSTenant", func() {
+				testTenant := &DBaaSTenant{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-tenant-1",
+					},
+					Spec: DBaaSTenantSpec{
+						InventoryNamespace: namespaceName,
+					},
+				}
+				By("creating DBaaSTenant")
+				Expect(k8sClient.Create(ctx, testTenant)).Should(MatchError("admission webhook \"vdbaastenant.kb.io\" denied the request: " +
+					"spec.inventoryNamespace: Invalid value: \"test-namespace\": the namespace test-namespace is already managed by tenant test-tenant, " +
+					"it cannot be managed by another tenant"))
+			})
+		})
+	})
+})

--- a/api/v1alpha1/webhook_suite_test.go
+++ b/api/v1alpha1/webhook_suite_test.go
@@ -116,6 +116,16 @@ var _ = BeforeSuite(func() {
 	err = (&DBaaSInventory{}).SetupWebhookWithManager(mgr)
 	Expect(err).NotTo(HaveOccurred())
 
+	err = (&DBaaSTenant{}).SetupWebhookWithManager(mgr)
+	Expect(err).NotTo(HaveOccurred())
+
+	err = mgr.GetFieldIndexer().IndexField(context.Background(), &DBaaSTenant{}, inventoryNamespaceKey, func(rawObj client.Object) []string {
+		tenant := rawObj.(*DBaaSTenant)
+		inventoryNS := tenant.Spec.InventoryNamespace
+		return []string{inventoryNS}
+	})
+	Expect(err).NotTo(HaveOccurred())
+
 	//+kubebuilder:scaffold:webhook
 
 	go func() {

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -45,3 +45,23 @@ webhooks:
     resources:
     - dbaasinventories
   sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-dbaas-redhat-com-v1alpha1-dbaastenant
+  failurePolicy: Fail
+  name: vdbaastenant.kb.io
+  rules:
+  - apiGroups:
+    - dbaas.redhat.com
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - dbaastenants
+  sideEffects: None

--- a/main.go
+++ b/main.go
@@ -179,6 +179,10 @@ func main() {
 			setupLog.Error(err, "unable to create webhook", "webhook", "DBaaSInventory")
 			os.Exit(1)
 		}
+		if err = (&v1alpha1.DBaaSTenant{}).SetupWebhookWithManager(mgr); err != nil {
+			setupLog.Error(err, "unable to create webhook", "webhook", "DBaaSTenant")
+			os.Exit(1)
+		}
 	}
 	if err = (&controllers.DBaaSTenantReconciler{
 		DBaaSAuthzReconciler: authzReconciler,


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and link to the related Jira issue. Please add any additional motivation and context as needed. Screenshots are also welcome -->
We should only allow one tenant object per inventory namespace. The validating webhook should check if an existing tenant exists with the same spec.inventoryNamespace setting. 

https://issues.redhat.com/browse/DBAAS-379

## Verification Steps
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.
-->

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA or in issue number have been completed
- [ ] Unit tests added that prove the fix is effective or the feature works 
- [ ] Documentation added for the feature
- [ ] all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer