### PR TITLE
DBAAS-364: Add a new Instance Phase `Error`, `Failed` and `Unknown`

### DIFF
--- a/api/v1alpha1/dbaasprovider.go
+++ b/api/v1alpha1/dbaasprovider.go
@@ -58,21 +58,24 @@ const (
 	MsgInvalidNamespace              string = "Invalid connection namespace for the referenced inventory"
 	MsgPolicyNotReady                string = "Another active Policy already exists"
 
-	// DBaaS instance provisioning phases
-
-	PhaseUnknown  string = "Unknown"
-	PhasePending  string = "Pending"
-	PhaseCreating string = "Creating"
-	PhaseUpdating string = "Updating"
-	PhaseDeleting string = "Deleting"
-	PhaseDeleted  string = "Deleted"
-	PhaseReady    string = "Ready"
-	PhaseError    string = "Error"
-	PhaseFailed   string = "Failed"
-
 	TypeLabelValue    = "credentials"
 	TypeLabelKey      = "db-operator/type"
 	TypeLabelKeyMongo = "atlas.mongodb.com/type"
+)
+
+// DBaasInstancePhase instance provisioning phases
+type DBaasInstancePhase string
+
+const (
+	InstancePhaseUnknown  DBaasInstancePhase = "Unknown"
+	InstancePhasePending  DBaasInstancePhase = "Pending"
+	InstancePhaseCreating DBaasInstancePhase = "Creating"
+	InstancePhaseUpdating DBaasInstancePhase = "Updating"
+	InstancePhaseDeleting DBaasInstancePhase = "Deleting"
+	InstancePhaseDeleted  DBaasInstancePhase = "Deleted"
+	InstancePhaseReady    DBaasInstancePhase = "Ready"
+	InstancePhaseError    DBaasInstancePhase = "Error"
+	InstancePhaseFailed   DBaasInstancePhase = "Failed"
 )
 
 // DBaaSProviderSpec defines the desired state of DBaaSProvider
@@ -265,7 +268,7 @@ type DBaaSInstanceStatus struct {
 	// Ready - cluster provisioning complete
 	// Error - cluster provisioning with error
 	// Failed - cluster provisioning failed
-	Phase string `json:"phase"`
+	Phase DBaasInstancePhase `json:"phase"`
 }
 
 // DBaaSProviderInstance is the schema for unmarshalling provider instance object

--- a/api/v1alpha1/dbaasprovider.go
+++ b/api/v1alpha1/dbaasprovider.go
@@ -253,13 +253,18 @@ type DBaaSInstanceStatus struct {
 	// Any other provider-specific information related to this instance
 	InstanceInfo map[string]string `json:"instanceInfo,omitempty"`
 
+	// +kubebuilder:validation:Enum=Unknown;Pending;Creating;Updating;Deleting;Deleted;Ready;Error;Failed
+	// +kubebuilder:default=Unknown
 	// Represents the cluster provisioning phase
+	// Unknown - unknown cluster provisioning status
 	// Pending - provisioning not yet started
 	// Creating - provisioning in progress
 	// Updating - cluster updating in progress
 	// Deleting - cluster deletion in progress
 	// Deleted - cluster has been deleted
 	// Ready - cluster provisioning complete
+	// Error - cluster provisioning with error
+	// Failed - cluster provisioning failed
 	Phase string `json:"phase"`
 }
 

--- a/bundle/manifests/dbaas.redhat.com_dbaasinstances.yaml
+++ b/bundle/manifests/dbaas.redhat.com_dbaasinstances.yaml
@@ -148,10 +148,23 @@ spec:
                   instance
                 type: object
               phase:
-                description: Represents the cluster provisioning phase Pending - provisioning
-                  not yet started Creating - provisioning in progress Updating - cluster
-                  updating in progress Deleting - cluster deletion in progress Deleted
-                  - cluster has been deleted Ready - cluster provisioning complete
+                default: Unknown
+                description: Represents the cluster provisioning phase Unknown - unknown
+                  cluster provisioning status Pending - provisioning not yet started
+                  Creating - provisioning in progress Updating - cluster updating
+                  in progress Deleting - cluster deletion in progress Deleted - cluster
+                  has been deleted Ready - cluster provisioning complete Error - cluster
+                  provisioning with error Failed - cluster provisioning failed
+                enum:
+                - Unknown
+                - Pending
+                - Creating
+                - Updating
+                - Deleting
+                - Deleted
+                - Ready
+                - Error
+                - Failed
                 type: string
             required:
             - instanceID

--- a/config/crd/bases/dbaas.redhat.com_dbaasinstances.yaml
+++ b/config/crd/bases/dbaas.redhat.com_dbaasinstances.yaml
@@ -150,10 +150,23 @@ spec:
                   instance
                 type: object
               phase:
-                description: Represents the cluster provisioning phase Pending - provisioning
-                  not yet started Creating - provisioning in progress Updating - cluster
-                  updating in progress Deleting - cluster deletion in progress Deleted
-                  - cluster has been deleted Ready - cluster provisioning complete
+                default: Unknown
+                description: Represents the cluster provisioning phase Unknown - unknown
+                  cluster provisioning status Pending - provisioning not yet started
+                  Creating - provisioning in progress Updating - cluster updating
+                  in progress Deleting - cluster deletion in progress Deleted - cluster
+                  has been deleted Ready - cluster provisioning complete Error - cluster
+                  provisioning with error Failed - cluster provisioning failed
+                enum:
+                - Unknown
+                - Pending
+                - Creating
+                - Updating
+                - Deleting
+                - Deleted
+                - Ready
+                - Error
+                - Failed
                 type: string
             required:
             - instanceID

--- a/controllers/dbaasinstance_controller.go
+++ b/controllers/dbaasinstance_controller.go
@@ -69,7 +69,7 @@ func (r *DBaaSInstanceReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 			Message: message,
 		}
 		apimeta.SetStatusCondition(&instance.Status.Conditions, cond)
-		instance.Status.Phase = "Error"
+		instance.Status.Phase = v1alpha1.InstancePhaseError
 	}, logger); err != nil {
 		SetInstanceMetrics(inventory.Spec.ProviderRef.Name, inventory.Name, instance, execution)
 		return ctrl.Result{}, err
@@ -121,6 +121,9 @@ func (r *DBaaSInstanceReconciler) SetupWithManager(mgr ctrl.Manager) (controller
 // mergeInstanceStatus: merge the status from DBaaSProviderInstance into the current DBaaSInstance status
 func mergeInstanceStatus(instance *v1alpha1.DBaaSInstance, providerInst *v1alpha1.DBaaSProviderInstance) metav1.Condition {
 	providerInst.Status.DeepCopyInto(&instance.Status)
+	if len(instance.Status.Phase) == 0 {
+		instance.Status.Phase = v1alpha1.InstancePhaseUnknown
+	}
 	// Update instance status condition (type: DBaaSInstanceReadyType) based on the provider status
 	specSync := apimeta.FindStatusCondition(providerInst.Status.Conditions, v1alpha1.DBaaSInstanceProviderSyncType)
 	if specSync != nil && specSync.Status == metav1.ConditionTrue {

--- a/controllers/dbaasinstance_controller.go
+++ b/controllers/dbaasinstance_controller.go
@@ -69,6 +69,7 @@ func (r *DBaaSInstanceReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 			Message: message,
 		}
 		apimeta.SetStatusCondition(&instance.Status.Conditions, cond)
+		instance.Status.Phase = "Error"
 	}, logger); err != nil {
 		SetInstanceMetrics(inventory.Spec.ProviderRef.Name, inventory.Name, instance, execution)
 		return ctrl.Result{}, err

--- a/controllers/dbaasinstance_controller_test.go
+++ b/controllers/dbaasinstance_controller_test.go
@@ -290,7 +290,7 @@ var _ = Describe("DBaaSInstance controller - nominal", func() {
 						InstanceInfo: map[string]string{
 							"instanceInfo": "test-instance-info",
 						},
-						Phase: "Ready",
+						Phase: v1alpha1.InstancePhaseReady,
 					}
 					It("should update DBaaSInstance status", assertDBaaSResourceProviderStatusUpdated(createdDBaaSInstance, metav1.ConditionTrue, testInstanceKind, status))
 				})
@@ -409,7 +409,7 @@ var _ = Describe("DBaaSInstance controller - valid dev namespaces", func() {
 						InstanceInfo: map[string]string{
 							"instanceInfo": "test-instance-info",
 						},
-						Phase: "Ready",
+						Phase: v1alpha1.InstancePhaseReady,
 					}
 					It("should update DBaaSInstance status", assertDBaaSResourceProviderStatusUpdated(createdDBaaSInstance, metav1.ConditionTrue, testInstanceKind, status))
 				})
@@ -523,7 +523,7 @@ var _ = Describe("DBaaSInstance controller - valid dev namespaces", func() {
 						InstanceInfo: map[string]string{
 							"instanceInfo": "test-instance-info",
 						},
-						Phase: "Ready",
+						Phase: v1alpha1.InstancePhaseReady,
 					}
 					It("should update DBaaSInstance status", assertDBaaSResourceProviderStatusUpdated(createdDBaaSInstance, metav1.ConditionTrue, testInstanceKind, status))
 				})

--- a/controllers/dbaasinstance_controller_test.go
+++ b/controllers/dbaasinstance_controller_test.go
@@ -290,7 +290,7 @@ var _ = Describe("DBaaSInstance controller - nominal", func() {
 						InstanceInfo: map[string]string{
 							"instanceInfo": "test-instance-info",
 						},
-						Phase: "ready",
+						Phase: "Ready",
 					}
 					It("should update DBaaSInstance status", assertDBaaSResourceProviderStatusUpdated(createdDBaaSInstance, metav1.ConditionTrue, testInstanceKind, status))
 				})
@@ -409,7 +409,7 @@ var _ = Describe("DBaaSInstance controller - valid dev namespaces", func() {
 						InstanceInfo: map[string]string{
 							"instanceInfo": "test-instance-info",
 						},
-						Phase: "ready",
+						Phase: "Ready",
 					}
 					It("should update DBaaSInstance status", assertDBaaSResourceProviderStatusUpdated(createdDBaaSInstance, metav1.ConditionTrue, testInstanceKind, status))
 				})
@@ -523,7 +523,7 @@ var _ = Describe("DBaaSInstance controller - valid dev namespaces", func() {
 						InstanceInfo: map[string]string{
 							"instanceInfo": "test-instance-info",
 						},
-						Phase: "ready",
+						Phase: "Ready",
 					}
 					It("should update DBaaSInstance status", assertDBaaSResourceProviderStatusUpdated(createdDBaaSInstance, metav1.ConditionTrue, testInstanceKind, status))
 				})

--- a/controllers/metrics.go
+++ b/controllers/metrics.go
@@ -339,21 +339,21 @@ func setInstancePhaseMetrics(provider string, account string, instance dbaasv1al
 	var phase float64
 
 	switch instance.Status.Phase {
-	case dbaasv1alpha1.PhasePending:
+	case dbaasv1alpha1.InstancePhasePending:
 		phase = -1
-	case dbaasv1alpha1.PhaseCreating:
+	case dbaasv1alpha1.InstancePhaseCreating:
 		phase = 0
-	case dbaasv1alpha1.PhaseReady:
+	case dbaasv1alpha1.InstancePhaseReady:
 		phase = 1
-	case dbaasv1alpha1.PhaseUnknown:
+	case dbaasv1alpha1.InstancePhaseUnknown:
 		phase = 2
-	case dbaasv1alpha1.PhaseFailed:
+	case dbaasv1alpha1.InstancePhaseFailed:
 		phase = 3
-	case dbaasv1alpha1.PhaseError:
+	case dbaasv1alpha1.InstancePhaseError:
 		phase = 4
-	case dbaasv1alpha1.PhaseDeleting:
+	case dbaasv1alpha1.InstancePhaseDeleting:
 		phase = 5
-	case dbaasv1alpha1.PhaseDeleted:
+	case dbaasv1alpha1.InstancePhaseDeleted:
 		phase = 6
 	}
 


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and link to the related Jira issue. Please add any additional motivation and context as needed. Screenshots are also welcome -->
Add a new Instance Phase `Error`, `Failed` and `Unknown`.  
Use them to indicate cluster terminal states with issues, for example CockroachDB Cloud`CreationFailed`.
Also add kubebuilder marker to the `Phase` field to enforce restriction on the allowed values and the default value.

Jira: https://issues.redhat.com/browse/DBAAS-364

This PR doesn't change any of the existing documented values for the Instance `Phase` field. As long as the provider operators use only the documented values, nothing will need to be updated on the provider operators' side.

Changes in this PR will set the Instance `Phase` field to use value `Unknown` in the scenarios where the provider operators don't set a value for the Phase field. The provider operators are supposed to explicitly set a value for the `Phase` field as long as the phase of the Instance can be determined. Otherwise, if the `Phase` field is not set, it should mean the phase of the Instance is unknown to the provider operators. So using `Unknown` as the default value should not cause any misunderstanding, and no update for the provider operators is needed in this case.

## Verification Steps
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.
-->

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA or in issue number have been completed
- [ ] Unit tests added that prove the fix is effective or the feature works 
- [ ] Documentation added for the feature
- [ ] all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer