### PR TITLE
[DBAAS-165] leverage RELATED_IMAGE functionality for image references

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ RUN go mod download
 COPY main.go main.go
 COPY api/ api/
 COPY controllers/ controllers/
+COPY config/ config/
 
 # Build
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager main.go

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Build the Red Hat OpenShift Database Access Operator image and push it to a publ
 
 Reqs:
  - go v1.17
- - operator-sdk v1.10.1
+ - operator-sdk v1.20.1
 
 **if you are using podman instead of docker set CONTAINER_ENGINE as podman** `export CONTAINER_ENGINE=podman`
 - `make build`

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -10,7 +10,7 @@ LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
 LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=dbaas-operator
 LABEL operators.operatorframework.io.bundle.channels.v1=alpha
-LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.10.0+git
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.19.0+git
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v3
 

--- a/bundle/manifests/dbaas-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/dbaas-operator.clusterserviceversion.yaml
@@ -158,7 +158,7 @@ metadata:
     description: Discover & connect with database instances hosted on 3rd-party ISV
       cloud platforms.
     operatorframework.io/suggested-namespace: openshift-dbaas-operator
-    operators.operatorframework.io/builder: operator-sdk-v1.10.0+git
+    operators.operatorframework.io/builder: operator-sdk-v1.19.0+git
     operators.operatorframework.io/internal-objects: '["dbaasconnections.dbaas.redhat.com","dbaasproviders.dbaas.redhat.com","dbaasplatforms.dbaas.redhat.com","dbaasinstances.dbaas.redhat.com"]'
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/RHEcosystemAppEng/dbaas-operator
@@ -399,7 +399,9 @@ spec:
           - create
         serviceAccountName: dbaas-operator-controller-manager
       deployments:
-      - name: dbaas-operator-controller-manager
+      - label:
+          control-plane: controller-manager
+        name: dbaas-operator-controller-manager
         spec:
           replicas: 1
           selector:
@@ -419,7 +421,7 @@ spec:
                 - --upstream=http://127.0.0.1:8080/
                 - --logtostderr=true
                 - --v=10
-                image: registry.redhat.io/openshift4/ose-kube-rbac-proxy:v4.8
+                image: registry.redhat.io/openshift4/ose-kube-rbac-proxy:v4.9
                 name: kube-rbac-proxy
                 ports:
                 - containerPort: 8443
@@ -438,6 +440,34 @@ spec:
                 command:
                 - /manager
                 env:
+                - name: RELATED_IMAGE_DBAAS_DYNAMIC_PLUGIN
+                  value: quay.io/ecosystem-appeng/dbaas-dynamic-plugin:0.3.0
+                - name: CSV_VERSION_DBAAS_DYNAMIC_PLUGIN
+                  value: dbaas-dynamic-plugin:0.3.0
+                - name: RELATED_IMAGE_CONSOLE_TELEMETRY_PLUGIN
+                  value: quay.io/ecosystem-appeng/console-telemetry-plugin:0.1.4
+                - name: CSV_VERSION_CONSOLE_TELEMETRY_PLUGIN
+                  value: console-telemetry-plugin:0.1.4
+                - name: RELATED_IMAGE_OBSERVABILITY_CATALOG
+                  value: quay.io/rhobs/observability-operator-catalog:0.0.12
+                - name: CSV_VERSION_OBSERVABILITY
+                  value: observability-operator.v0.0.12
+                - name: RELATED_IMAGE_CRUNCHY_BRIDGE_CATALOG
+                  value: registry.developers.crunchydata.com/crunchydata/crunchy-bridge-operator-catalog:v0.0.5
+                - name: CSV_VERSION_CRUNCHY_BRIDGE
+                  value: crunchy-bridge-operator.v0.0.5
+                - name: RELATED_IMAGE_MONGODB_ATLAS_CATALOG
+                  value: quay.io/mongodb/mongodb-atlas-kubernetes-dbaas-catalog:0.2.0
+                - name: CSV_VERSION_MONGODB_ATLAS
+                  value: mongodb-atlas-kubernetes.v0.2.0
+                - name: RELATED_IMAGE_COCKROACHDB_CATALOG
+                  value: gcr.io/cockroach-shared/ccapi-k8s-operator-catalog:v0.0.3
+                - name: CSV_VERSION_COCKROACHDB
+                  value: ccapi-k8s-operator.v0.0.3
+                - name: RELATED_IMAGE_RDS_PROVIDER_CATALOG
+                  value: quay.io/ecosystem-appeng/rds-dbaas-operator-catalog:v0.1.0
+                - name: CSV_VERSION_RDS_PROVIDER
+                  value: rds-dbaas-operator.v0.1.0
                 - name: INSTALL_NAMESPACE
                   valueFrom:
                     fieldRef:
@@ -536,6 +566,21 @@ spec:
   provider:
     name: Red Hat
     url: https://www.redhat.com
+  relatedImages:
+  - image: quay.io/ecosystem-appeng/dbaas-dynamic-plugin:0.3.0
+    name: dbaas-dynamic-plugin
+  - image: quay.io/ecosystem-appeng/console-telemetry-plugin:0.1.4
+    name: console-telemetry-plugin
+  - image: quay.io/rhobs/observability-operator-catalog:0.0.12
+    name: observability-catalog
+  - image: registry.developers.crunchydata.com/crunchydata/crunchy-bridge-operator-catalog:v0.0.5
+    name: crunchy-bridge-catalog
+  - image: quay.io/mongodb/mongodb-atlas-kubernetes-dbaas-catalog:0.2.0
+    name: mongodb-atlas-catalog
+  - image: gcr.io/cockroach-shared/ccapi-k8s-operator-catalog:v0.0.3
+    name: cockroachdb-catalog
+  - image: quay.io/ecosystem-appeng/rds-dbaas-operator-catalog:v0.1.0
+    name: rds-provider-catalog
   replaces: dbaas-operator.v0.2.0
   version: 0.3.0
   webhookdefinitions:

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -9,7 +9,7 @@ annotations:
   operators.operatorframework.io.bundle.metadata.v1: metadata/
   operators.operatorframework.io.bundle.package.v1: dbaas-operator
   operators.operatorframework.io.bundle.channels.v1: alpha
-  operators.operatorframework.io.metrics.builder: operator-sdk-v1.10.0+git
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.19.0+git
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v3
 

--- a/bundle/tests/scorecard/config.yaml
+++ b/bundle/tests/scorecard/config.yaml
@@ -12,6 +12,9 @@ stages:
     labels:
       suite: basic
       test: basic-check-spec-test
+    storage:
+      spec:
+        mountPath: {}
   - entrypoint:
     - scorecard-test
     - olm-bundle-validation
@@ -19,6 +22,9 @@ stages:
     labels:
       suite: olm
       test: olm-bundle-validation-test
+    storage:
+      spec:
+        mountPath: {}
   - entrypoint:
     - scorecard-test
     - olm-crds-have-validation
@@ -26,6 +32,9 @@ stages:
     labels:
       suite: olm
       test: olm-crds-have-validation-test
+    storage:
+      spec:
+        mountPath: {}
   - entrypoint:
     - scorecard-test
     - olm-crds-have-resources
@@ -33,6 +42,9 @@ stages:
     labels:
       suite: olm
       test: olm-crds-have-resources-test
+    storage:
+      spec:
+        mountPath: {}
   - entrypoint:
     - scorecard-test
     - olm-spec-descriptors
@@ -40,6 +52,9 @@ stages:
     labels:
       suite: olm
       test: olm-spec-descriptors-test
+    storage:
+      spec:
+        mountPath: {}
   - entrypoint:
     - scorecard-test
     - olm-status-descriptors
@@ -47,3 +62,9 @@ stages:
     labels:
       suite: olm
       test: olm-status-descriptors-test
+    storage:
+      spec:
+        mountPath: {}
+storage:
+  spec:
+    mountPath: {}

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -38,6 +38,9 @@ patchesStrategicMerge:
 # crd/kustomization.yaml
 - manager_webhook_patch.yaml
 
+# related images
+- manager-env-images.yaml
+
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'.
 # Uncomment 'CERTMANAGER' sections in crd/kustomization.yaml to enable the CA injection in the admission webhooks.
 # 'CERTMANAGER' needs to be enabled to use ca injection

--- a/config/default/manager-env-images.yaml
+++ b/config/default/manager-env-images.yaml
@@ -1,0 +1,40 @@
+# This patch injects all third-party related images and version information
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager
+        env:
+        - name: RELATED_IMAGE_DBAAS_DYNAMIC_PLUGIN
+          value: quay.io/ecosystem-appeng/dbaas-dynamic-plugin:0.3.0
+        - name: CSV_VERSION_DBAAS_DYNAMIC_PLUGIN
+          value: dbaas-dynamic-plugin:0.3.0
+        - name: RELATED_IMAGE_CONSOLE_TELEMETRY_PLUGIN
+          value: quay.io/ecosystem-appeng/console-telemetry-plugin:0.1.4
+        - name: CSV_VERSION_CONSOLE_TELEMETRY_PLUGIN
+          value: console-telemetry-plugin:0.1.4
+        - name: RELATED_IMAGE_OBSERVABILITY_CATALOG
+          value: quay.io/rhobs/observability-operator-catalog:0.0.12
+        - name: CSV_VERSION_OBSERVABILITY
+          value: observability-operator.v0.0.12
+        - name: RELATED_IMAGE_CRUNCHY_BRIDGE_CATALOG
+          value: registry.developers.crunchydata.com/crunchydata/crunchy-bridge-operator-catalog:v0.0.5
+        - name: CSV_VERSION_CRUNCHY_BRIDGE
+          value: crunchy-bridge-operator.v0.0.5
+        - name: RELATED_IMAGE_MONGODB_ATLAS_CATALOG
+          value: quay.io/mongodb/mongodb-atlas-kubernetes-dbaas-catalog:0.2.0
+        - name: CSV_VERSION_MONGODB_ATLAS
+          value: mongodb-atlas-kubernetes.v0.2.0
+        - name: RELATED_IMAGE_COCKROACHDB_CATALOG
+          value: gcr.io/cockroach-shared/ccapi-k8s-operator-catalog:v0.0.3
+        - name: CSV_VERSION_COCKROACHDB
+          value: ccapi-k8s-operator.v0.0.3
+        - name: RELATED_IMAGE_RDS_PROVIDER_CATALOG
+          value: quay.io/ecosystem-appeng/rds-dbaas-operator-catalog:v0.1.0
+        - name: CSV_VERSION_RDS_PROVIDER
+          value: rds-dbaas-operator.v0.1.0

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
       - name: kube-rbac-proxy
-        image: registry.redhat.io/openshift4/ose-kube-rbac-proxy:v4.8
+        image: registry.redhat.io/openshift4/ose-kube-rbac-proxy:v4.9
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"

--- a/config/embed.go
+++ b/config/embed.go
@@ -1,0 +1,8 @@
+package embeddedconfigs
+
+import (
+	_ "embed"
+)
+
+//go:embed default/manager-env-images.yaml
+var EnvImages []byte

--- a/controllers/reconcilers/constants.go
+++ b/controllers/reconcilers/constants.go
@@ -1,7 +1,12 @@
 package reconcilers
 
 import (
+	"os"
+
 	dbaasv1alpha1 "github.com/RHEcosystemAppEng/dbaas-operator/api/v1alpha1"
+	embeddedconfigs "github.com/RHEcosystemAppEng/dbaas-operator/config"
+	"gopkg.in/yaml.v3"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -12,8 +17,8 @@ const (
 	CONSOLE_PLUGIN_49_TAG          = "-4.9"
 
 	// CRUNCHY_BRIDGE
-	CRUNCHY_BRIDGE_CATALOG_IMG = "registry.developers.crunchydata.com/crunchydata/crunchy-bridge-operator-catalog:v0.0.5"
-	CRUNCHY_BRIDGE_CSV         = "crunchy-bridge-operator.v0.0.5"
+	CRUNCHY_BRIDGE_CATALOG_IMG = "RELATED_IMAGE_CRUNCHY_BRIDGE_CATALOG"
+	CRUNCHY_BRIDGE_CSV         = "CSV_VERSION_CRUNCHY_BRIDGE"
 	CRUNCHY_BRIDGE_NAME        = "crunchy-bridge"
 	CRUNCHY_BRIDGE_DISPLAYNAME = "Crunchy Bridge Operator"
 	CRUNCHY_BRIDGE_DEPLOYMENT  = "crunchy-bridge-operator-controller-manager"
@@ -21,8 +26,8 @@ const (
 	CRUNCHY_BRIDGE_CHANNEL     = "alpha"
 
 	// MONGODB_ATLAS
-	MONGODB_ATLAS_CATALOG_IMG = "quay.io/mongodb/mongodb-atlas-kubernetes-dbaas-catalog:0.2.0"
-	MONGODB_ATLAS_CSV         = "mongodb-atlas-kubernetes.v0.2.0"
+	MONGODB_ATLAS_CATALOG_IMG = "RELATED_IMAGE_MONGODB_ATLAS_CATALOG"
+	MONGODB_ATLAS_CSV         = "CSV_VERSION_MONGODB_ATLAS"
 	MONGODB_ATLAS_NAME        = "mongodb-atlas"
 	MONGODB_ATLAS_DISPLAYNAME = "MongoDB Atlas Operator"
 	MONGODB_ATLAS_DEPLOYMENT  = "mongodb-atlas-operator"
@@ -30,8 +35,8 @@ const (
 	MONGODB_ATLAS_CHANNEL     = "beta"
 
 	// COCKROACHDB
-	COCKROACHDB_CSV         = "ccapi-k8s-operator.v0.0.3"
-	COCKROACHDB_CATALOG_IMG = "gcr.io/cockroach-shared/ccapi-k8s-operator-catalog:v0.0.3"
+	COCKROACHDB_CSV         = "CSV_VERSION_COCKROACHDB"
+	COCKROACHDB_CATALOG_IMG = "RELATED_IMAGE_COCKROACHDB_CATALOG"
 	COCKROACHDB_NAME        = "ccapi-k8s"
 	COCKROACHDB_DISPLAYNAME = "CockroachDB Cloud Operator"
 	COCKROACHDB_DEPLOYMENT  = "ccapi-k8s-operator-controller-manager"
@@ -39,22 +44,22 @@ const (
 	COCKROACHDB_CHANNEL     = "alpha"
 
 	// DBAAS_DYNAMIC_PLUGIN
-	DBAAS_DYNAMIC_PLUGIN_IMG          = "quay.io/ecosystem-appeng/dbaas-dynamic-plugin:0.2.0"
-	DBAAS_DYNAMIC_PLUGIN_VERSION      = "dbaas-dynamic-plugin:0.2.0"
+	DBAAS_DYNAMIC_PLUGIN_IMG          = "RELATED_IMAGE_DBAAS_DYNAMIC_PLUGIN"
+	DBAAS_DYNAMIC_PLUGIN_VERSION      = "CSV_VERSION_DBAAS_DYNAMIC_PLUGIN"
 	DBAAS_DYNAMIC_PLUGIN_NAME         = "dbaas-dynamic-plugin"
 	DBAAS_DYNAMIC_PLUGIN_DISPLAY_NAME = "OpenShift Database as a Service Dynamic Plugin"
 
 	// CONSOLE_TELEMETRY_PLUGIN
-	CONSOLE_TELEMETRY_PLUGIN_IMG             = "quay.io/ecosystem-appeng/console-telemetry-plugin:0.1.4"
-	CONSOLE_TELEMETRY_PLUGIN_VERSION         = "console-telemetry-plugin:0.1.4"
+	CONSOLE_TELEMETRY_PLUGIN_IMG             = "RELATED_IMAGE_CONSOLE_TELEMETRY_PLUGIN"
+	CONSOLE_TELEMETRY_PLUGIN_VERSION         = "CSV_VERSION_CONSOLE_TELEMETRY_PLUGIN"
 	CONSOLE_TELEMETRY_PLUGIN_NAME            = "console-telemetry-plugin"
 	CONSOLE_TELEMETRY_PLUGIN_DISPLAY_NAME    = "Telemetry Plugin"
 	CONSOLE_TELEMETRY_PLUGIN_SEGMENT_KEY_ENV = "SEGMENT_KEY"
 	CONSOLE_TELEMETRY_PLUGIN_SEGMENT_KEY     = "qejcCDG37ICCLIDsM1FcJDkd68hglCoK"
 
 	// RDS_PROVIDER
-	RDS_PROVIDER_CSV         = "rds-dbaas-operator.v0.1.0"
-	RDS_PROVIDER_CATALOG_IMG = "quay.io/ecosystem-appeng/rds-dbaas-operator-catalog:v0.1.0"
+	RDS_PROVIDER_CSV         = "CSV_VERSION_RDS_PROVIDER"
+	RDS_PROVIDER_CATALOG_IMG = "RELATED_IMAGE_RDS_PROVIDER_CATALOG"
 	RDS_PROVIDER_NAME        = "rds-provider"
 	RDS_PROVIDER_DISPLAYNAME = "RHODA Provider Operator for Amazon RDS"
 	RDS_PROVIDER_DEPLOYMENT  = "rds-dbaas-operator-controller-manager"
@@ -62,8 +67,8 @@ const (
 	RDS_PROVIDER_CHANNEL     = "alpha"
 
 	// OBSERVABILITY
-	OBSERVABILITY_CATALOG_IMG = "quay.io/rhobs/observability-operator-catalog:0.0.12"
-	OBSERVABILITY_CSV         = "observability-operator.v0.0.12"
+	OBSERVABILITY_CATALOG_IMG = "RELATED_IMAGE_OBSERVABILITY_CATALOG"
+	OBSERVABILITY_CSV         = "CSV_VERSION_OBSERVABILITY"
 	OBSERVABILITY_NAME        = "observability"
 	OBSERVABILITY_DISPLAYNAME = "observability Operator"
 	OBSERVABILITY_DEPLOYMENT  = "observability-operator"
@@ -74,24 +79,24 @@ const (
 var InstallationPlatforms = map[dbaasv1alpha1.PlatformsName]dbaasv1alpha1.PlatformConfig{
 	dbaasv1alpha1.DBaaSDynamicPluginInstallation: {
 		Name:        DBAAS_DYNAMIC_PLUGIN_NAME,
-		Image:       DBAAS_DYNAMIC_PLUGIN_IMG,
+		Image:       fetchEnvValue(DBAAS_DYNAMIC_PLUGIN_IMG),
 		DisplayName: DBAAS_DYNAMIC_PLUGIN_DISPLAY_NAME,
-		CSV:         DBAAS_DYNAMIC_PLUGIN_VERSION,
+		CSV:         fetchEnvValue(DBAAS_DYNAMIC_PLUGIN_VERSION),
 		Type:        dbaasv1alpha1.TypeConsolePlugin,
 	},
 	dbaasv1alpha1.ConsoleTelemetryPluginInstallation: {
 		Name:        CONSOLE_TELEMETRY_PLUGIN_NAME,
-		Image:       CONSOLE_TELEMETRY_PLUGIN_IMG,
+		Image:       fetchEnvValue(CONSOLE_TELEMETRY_PLUGIN_IMG),
 		DisplayName: CONSOLE_TELEMETRY_PLUGIN_DISPLAY_NAME,
-		CSV:         CONSOLE_TELEMETRY_PLUGIN_VERSION,
+		CSV:         fetchEnvValue(CONSOLE_TELEMETRY_PLUGIN_VERSION),
 		Envs:        []corev1.EnvVar{{Name: CONSOLE_TELEMETRY_PLUGIN_SEGMENT_KEY_ENV, Value: CONSOLE_TELEMETRY_PLUGIN_SEGMENT_KEY}},
 		Type:        dbaasv1alpha1.TypeConsolePlugin,
 	},
 	dbaasv1alpha1.CrunchyBridgeInstallation: {
 		Name:           CRUNCHY_BRIDGE_NAME,
-		CSV:            CRUNCHY_BRIDGE_CSV,
+		CSV:            fetchEnvValue(CRUNCHY_BRIDGE_CSV),
 		DeploymentName: CRUNCHY_BRIDGE_DEPLOYMENT,
-		Image:          CRUNCHY_BRIDGE_CATALOG_IMG,
+		Image:          fetchEnvValue(CRUNCHY_BRIDGE_CATALOG_IMG),
 		PackageName:    CRUNCHY_BRIDGE_PKG,
 		Channel:        CRUNCHY_BRIDGE_CHANNEL,
 		DisplayName:    CRUNCHY_BRIDGE_DISPLAYNAME,
@@ -99,9 +104,9 @@ var InstallationPlatforms = map[dbaasv1alpha1.PlatformsName]dbaasv1alpha1.Platfo
 	},
 	dbaasv1alpha1.MongoDBAtlasInstallation: {
 		Name:           MONGODB_ATLAS_NAME,
-		CSV:            MONGODB_ATLAS_CSV,
+		CSV:            fetchEnvValue(MONGODB_ATLAS_CSV),
 		DeploymentName: MONGODB_ATLAS_DEPLOYMENT,
-		Image:          MONGODB_ATLAS_CATALOG_IMG,
+		Image:          fetchEnvValue(MONGODB_ATLAS_CATALOG_IMG),
 		PackageName:    MONGODB_ATLAS_PKG,
 		Channel:        MONGODB_ATLAS_CHANNEL,
 		DisplayName:    MONGODB_ATLAS_DISPLAYNAME,
@@ -109,9 +114,9 @@ var InstallationPlatforms = map[dbaasv1alpha1.PlatformsName]dbaasv1alpha1.Platfo
 	},
 	dbaasv1alpha1.CockroachDBInstallation: {
 		Name:           COCKROACHDB_NAME,
-		CSV:            COCKROACHDB_CSV,
+		CSV:            fetchEnvValue(COCKROACHDB_CSV),
 		DeploymentName: COCKROACHDB_DEPLOYMENT,
-		Image:          COCKROACHDB_CATALOG_IMG,
+		Image:          fetchEnvValue(COCKROACHDB_CATALOG_IMG),
 		PackageName:    COCKROACHDB_PKG,
 		Channel:        COCKROACHDB_CHANNEL,
 		DisplayName:    COCKROACHDB_DISPLAYNAME,
@@ -122,9 +127,9 @@ var InstallationPlatforms = map[dbaasv1alpha1.PlatformsName]dbaasv1alpha1.Platfo
 	},
 	dbaasv1alpha1.RDSProviderInstallation: {
 		Name:           RDS_PROVIDER_NAME,
-		CSV:            RDS_PROVIDER_CSV,
+		CSV:            fetchEnvValue(RDS_PROVIDER_CSV),
 		DeploymentName: RDS_PROVIDER_DEPLOYMENT,
-		Image:          RDS_PROVIDER_CATALOG_IMG,
+		Image:          fetchEnvValue(RDS_PROVIDER_CATALOG_IMG),
 		PackageName:    RDS_PROVIDER_PKG,
 		Channel:        RDS_PROVIDER_CHANNEL,
 		DisplayName:    RDS_PROVIDER_DISPLAYNAME,
@@ -132,12 +137,36 @@ var InstallationPlatforms = map[dbaasv1alpha1.PlatformsName]dbaasv1alpha1.Platfo
 	},
 	dbaasv1alpha1.ObservabilityInstallation: {
 		Name:           OBSERVABILITY_NAME,
-		CSV:            OBSERVABILITY_CSV,
+		CSV:            fetchEnvValue(OBSERVABILITY_CSV),
 		DeploymentName: OBSERVABILITY_DEPLOYMENT,
-		Image:          OBSERVABILITY_CATALOG_IMG,
+		Image:          fetchEnvValue(OBSERVABILITY_CATALOG_IMG),
 		PackageName:    OBSERVABILITY_PKG,
 		Channel:        OBSERVABILITY_CHANNEL,
 		DisplayName:    OBSERVABILITY_DISPLAYNAME,
 		Type:           dbaasv1alpha1.TypeOperator,
 	},
+}
+
+// fetchEnvValue returns the value of a set variable. if env var not set, returns the
+// 		default value from an embedded yaml file.
+func fetchEnvValue(envVar string) (imageValue string) {
+	imageValue, found := os.LookupEnv(envVar)
+	if !found {
+		tmpDep := &appsv1.Deployment{}
+		if err := yaml.Unmarshal(embeddedconfigs.EnvImages, tmpDep); err != nil {
+			return imageValue
+		}
+		return getEnvVarValue(envVar, tmpDep.Spec.Template.Spec.Containers[0].Env)
+	}
+	return imageValue
+}
+
+// getEnvVarValue returns the value of an EnvVar by name
+func getEnvVarValue(envName string, env []corev1.EnvVar) string {
+	for _, v := range env {
+		if v.Name == envName {
+			return v.Value
+		}
+	}
+	return ""
 }

--- a/controllers/reconcilers/constants_test.go
+++ b/controllers/reconcilers/constants_test.go
@@ -1,0 +1,37 @@
+package reconcilers
+
+import (
+	"os"
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var repoOrg = "quay.io/ecosystem-appeng/"
+var _ = Describe("FetchImageAndVersion", func() {
+	Context("Missing env var", func() {
+		It("invalid, should return empty value", func() {
+			os.Unsetenv("FOO")
+			Expect(fetchEnvValue("FOO")).To(BeEmpty())
+		})
+		It("valid, should return default values from embedded file - config/default/manager-env-images.yaml", func() {
+			os.Unsetenv(DBAAS_DYNAMIC_PLUGIN_VERSION)
+			os.Unsetenv(DBAAS_DYNAMIC_PLUGIN_IMG)
+			Expect(fetchEnvValue(DBAAS_DYNAMIC_PLUGIN_IMG)).To(Equal(repoOrg + fetchEnvValue(DBAAS_DYNAMIC_PLUGIN_VERSION)))
+		})
+	})
+
+	Context("Existing env var", func() {
+		It("should return set value", func() {
+			imageTest := "test-image@sha256:fds45ds21kl"
+			os.Setenv(DBAAS_DYNAMIC_PLUGIN_IMG, imageTest)
+			Expect(fetchEnvValue(DBAAS_DYNAMIC_PLUGIN_IMG)).To(Equal(imageTest))
+		})
+	})
+})
+
+func Test(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "FetchEnvValue Suite")
+}

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/rhobs/observability-operator v0.0.11
 	go.uber.org/zap v1.19.1
 	golang.org/x/mod v0.5.1
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 	k8s.io/api v0.23.5
 	k8s.io/apimachinery v0.23.5
 	k8s.io/client-go v0.23.5
@@ -73,7 +74,6 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 	k8s.io/apiextensions-apiserver v0.23.5 // indirect
 	k8s.io/component-base v0.23.5 // indirect
 	k8s.io/klog/v2 v2.30.0 // indirect

--- a/wrapper.Dockerfile
+++ b/wrapper.Dockerfile
@@ -1,5 +1,5 @@
 # 0.2.0 catalog image
-FROM quay.io/osd-addons/dbaas-operator-index@sha256:b699851c2a839ee85a98a8daf3b619c0b34716c081046b229c37e8ea2d2efa96
+FROM quay.io/osd-addons/dbaas-operator-index@sha256:f7bd64974ab6c2d4e055fdd5de7939961db2306e28282350d34c9ddb85bbb50c
 
 # fix for https://issues.redhat.com/browse/MTSRE-612
 RUN chmod u+w /root /usr/bin /usr/lib /usr/lib64 /usr/lib64/pm-utils


### PR DESCRIPTION
 - removes hard-coded, release-specific configs... moves images and versions to env vars. should be set in `config/default/manager-env-images.yaml`
 - should env var(s) be missing, it will use default(s) via embedded yaml file
 - option to use image digests in csv, w/ `make bundle-w-digests`. example of result - https://gist.github.com/tchughesiv/6b0d19518797bfe6d138b0471e45100a
 - upgrade to operator-sdk v1.20.1

Signed-off-by: Tommy Hughes <tohughes@redhat.com>
