### PR TITLE
Expose the port required for Service Monitor to read the metrics from the metrics service

### DIFF
--- a/bundle/manifests/dbaas-operator-controller-manager-metrics-service_v1_service.yaml
+++ b/bundle/manifests/dbaas-operator-controller-manager-metrics-service_v1_service.yaml
@@ -3,13 +3,14 @@ kind: Service
 metadata:
   creationTimestamp: null
   labels:
+    app: dbaas-prometheus
     control-plane: controller-manager
   name: dbaas-operator-controller-manager-metrics-service
 spec:
   ports:
-  - name: https
+  - name: metrics
     port: 8443
-    targetPort: https
+    targetPort: metrics
   selector:
     control-plane: controller-manager
 status:

--- a/bundle/manifests/dbaas-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/dbaas-operator.clusterserviceversion.yaml
@@ -446,7 +446,7 @@ spec:
                   readOnlyRootFilesystem: true
               - args:
                 - --health-probe-bind-address=:8081
-                - --metrics-bind-address=127.0.0.1:8080
+                - --metrics-bind-address=0.0.0.0:8080
                 - --leader-elect
                 command:
                 - /manager
@@ -468,6 +468,8 @@ spec:
                 - containerPort: 9443
                   name: webhook-server
                   protocol: TCP
+                - containerPort: 8080
+                  name: metrics
                 readinessProbe:
                   httpGet:
                     path: /readyz

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -26,7 +26,10 @@ spec:
             drop:
             - ALL
       - name: manager
+        ports:
+          - containerPort: 8080
+            name: metrics
         args:
         - "--health-probe-bind-address=:8081"
-        - "--metrics-bind-address=127.0.0.1:8080"
+        - "--metrics-bind-address=0.0.0.0:8080"
         - "--leader-elect"

--- a/config/rbac/auth_proxy_service.yaml
+++ b/config/rbac/auth_proxy_service.yaml
@@ -2,13 +2,14 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
+    app: dbaas-prometheus
     control-plane: controller-manager
   name: controller-manager-metrics-service
   namespace: system
 spec:
   ports:
-  - name: https
+  - name: metrics
     port: 8443
-    targetPort: https
+    targetPort: metrics
   selector:
     control-plane: controller-manager

--- a/controllers/metrics.go
+++ b/controllers/metrics.go
@@ -22,7 +22,6 @@ const (
 	installationTimeStart = 0
 	// installationTimeWidth is the width of a bucket in the histogram, here it is 1m
 	installationTimeWidth = 60
-
 	// installationTimeBuckets is the number of buckets, here it 10 minutes worth of 1m buckets
 	installationTimeBuckets = 10
 )


### PR DESCRIPTION
## Description
The metrics are currently exposed via the pod, to enable Prometheus to read metrics, we need to expose the metrics from the service, this PR opens the port required on the pod and service to achieve that.

This PR depends on https://github.com/RHEcosystemAppEng/dbaas-operator/pull/171
## Verification Steps

1. Deploy the operator.
2. From the terminal port-forward the service as `oc port-forward svc/dbaas-operator-controller-manager-metrics-service 28015:808 -n openshift-dbaas-operator`
3. Curl the metrics URL `curl http://localhost:8080/metrics`
4. Verify that the metrics, `dbaas_stack_installation_duration_seconds` and give the total time and status of platform components the installation.

Metrics Results:
```
# HELP dbaas_platform_installation_status status of an installation of components and provider operators. values (success=1,failed=0, in progress=2) 
# TYPE dbaas_platform_installation_status gauge
dbaas_platform_installation_status{name="cockroachdb-cloud",status="in progress",version="ccapi-k8s-operator.v0.0.2"} 2
dbaas_platform_installation_status{name="console-telemetry-plugin",status="failed",version=""} 0
dbaas_platform_installation_status{name="console-telemetry-plugin",status="in progress",version=""} 2
dbaas_platform_installation_status{name="crunchy-bridge",status="failed",version="crunchy-bridge-operator.v0.0.4"} 0
dbaas_platform_installation_status{name="crunchy-bridge",status="in progress",version="crunchy-bridge-operator.v0.0.4"} 2
dbaas_platform_installation_status{name="dbaas-dynamic-plugin",status="failed",version=""} 0
dbaas_platform_installation_status{name="dbaas-dynamic-plugin",status="in progress",version=""} 2
dbaas_platform_installation_status{name="dbaas-quick-starts",status="success",version=""} 1
dbaas_platform_installation_status{name="mongodb-atlas",status="failed",version="mongodb-atlas-kubernetes.v0.3.0"} 0
dbaas_platform_installation_status{name="mongodb-atlas",status="in progress",version="mongodb-atlas-kubernetes.v0.3.0"} 2
# HELP dbaas_stack_installation_total_duration_seconds How long in seconds installation of a DBaaS stack takes.
# TYPE dbaas_stack_installation_total_duration_seconds histogram
dbaas_stack_installation_total_duration_seconds_bucket{version="dbaas-operator.v0.2.70",le="0"} 0
dbaas_stack_installation_total_duration_seconds_bucket{version="dbaas-operator.v0.2.70",le="60"} 33
dbaas_stack_installation_total_duration_seconds_bucket{version="dbaas-operator.v0.2.70",le="120"} 33
dbaas_stack_installation_total_duration_seconds_bucket{version="dbaas-operator.v0.2.70",le="180"} 33
dbaas_stack_installation_total_duration_seconds_bucket{version="dbaas-operator.v0.2.70",le="240"} 33
dbaas_stack_installation_total_duration_seconds_bucket{version="dbaas-operator.v0.2.70",le="300"} 33
dbaas_stack_installation_total_duration_seconds_bucket{version="dbaas-operator.v0.2.70",le="360"} 33
dbaas_stack_installation_total_duration_seconds_bucket{version="dbaas-operator.v0.2.70",le="420"} 33
dbaas_stack_installation_total_duration_seconds_bucket{version="dbaas-operator.v0.2.70",le="480"} 33
dbaas_stack_installation_total_duration_seconds_bucket{version="dbaas-operator.v0.2.70",le="540"} 33
dbaas_stack_installation_total_duration_seconds_bucket{version="dbaas-operator.v0.2.70",le="+Inf"} 33
dbaas_stack_installation_total_duration_seconds_sum{version="dbaas-operator.v0.2.70"} 1.4552783039999997
dbaas_stack_installation_total_duration_seconds_count{version="dbaas-operator.v0.2.70"} 33
```
## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA or in issue number have been completed
- [ ] Unit tests added that prove the fix is effective or the feature works 
- [ ] Documentation added for the feature
- [ ] all relevant tests are passing
- [x] Code Review completed
- [x] Verified independently by reviewer