### PR TITLE
Add ServiceMonitor and MonitoringStackOperator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -268,3 +268,15 @@ catalog-build: opm ## Build a catalog image.
 .PHONY: catalog-push
 catalog-push: ## Push a catalog image.
 	$(MAKE) docker-push IMG=$(CATALOG_IMG)
+
+mso-install:
+	oc apply -f config/samples/mso-catalog-source-subscription.yaml
+
+mso-uninstall:
+	oc delete -f config/samples/mso-catalog-source-subscription.yaml
+
+deploy-mso:
+	oc apply -f config/samples/mso.yaml
+
+undeploy-mso:
+	oc delete monitoringstack dbaas-operator-mso

--- a/bundle/manifests/dbaas-operator-service-monitor_monitoring.coreos.com_v1_servicemonitor.yaml
+++ b/bundle/manifests/dbaas-operator-service-monitor_monitoring.coreos.com_v1_servicemonitor.yaml
@@ -1,0 +1,14 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app: dbaas-prometheus
+  name: dbaas-operator-service-monitor
+spec:
+  endpoints:
+  - interval: 30s
+    path: /metrics
+    port: metrics
+  selector:
+    matchLabels:
+      app: dbaas-prometheus

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -22,7 +22,7 @@ bases:
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'. 'WEBHOOK' components are required.
 #- ../certmanager
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
-#- ../prometheus
+- ../prometheus
 
 patchesStrategicMerge:
 # Protect the /metrics endpoint by putting it behind auth.

--- a/config/prometheus/kustomization.yaml
+++ b/config/prometheus/kustomization.yaml
@@ -1,2 +1,3 @@
 resources:
-- monitor.yaml
+#- monitor.yaml
+- service_monitor.yaml

--- a/config/prometheus/service_monitor.yaml
+++ b/config/prometheus/service_monitor.yaml
@@ -1,0 +1,15 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app: dbaas-prometheus
+  name: service-monitor
+  namespace: system
+spec:
+  endpoints:
+    - interval: 30s
+      path: /metrics
+      port: metrics
+  selector:
+    matchLabels:
+      app: dbaas-prometheus

--- a/config/samples/catalog-operator-group.yaml
+++ b/config/samples/catalog-operator-group.yaml
@@ -2,6 +2,3 @@ apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:
   name: dbaas-operator-group
-spec:
-  targetNamespaces:
-    - <your_target_namespace>

--- a/config/samples/mso-catalog-source-subscription.yaml
+++ b/config/samples/mso-catalog-source-subscription.yaml
@@ -1,0 +1,24 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: monitoring-operators
+  namespace: openshift-marketplace
+spec:
+  displayName: Monitoring Stack Operator
+  image: quay.io/rhobs/monitoring-stack-operator-catalog:latest
+  sourceType: grpc
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  labels:
+    operators.coreos.com/monitoring-stack-operator.openshift-operators: ''
+  name: monitoring-stack-operator
+  namespace: openshift-operators
+spec:
+  channel: development
+  installPlanApproval: Automatic
+  name: monitoring-stack-operator
+  source: monitoring-operators
+  sourceNamespace: openshift-marketplace
+  startingCSV: monitoring-stack-operator.v0.0.8

--- a/config/samples/mso.yaml
+++ b/config/samples/mso.yaml
@@ -1,0 +1,9 @@
+apiVersion: monitoring.rhobs/v1alpha1
+kind: MonitoringStack
+metadata:
+  name: dbaas-operator-mso
+spec:
+  logLevel: debug
+  resourceSelector:
+    matchLabels:
+      app: dbaas-prometheus

--- a/docs/install-mso.md
+++ b/docs/install-mso.md
@@ -1,0 +1,24 @@
+# Install and Deploy MSO instance
+___
+
+We have to deploy the MSO after installing the dbaas-operator on the cluster so that we can see and query the metrics from Prometheus UI.
+
+## Steps to Deploy MSO
+
+```commandline
+make install-mso 
+// Deploys the catalog source and subscription for MSO.
+
+make deploy-mso
+// Applys the MSO CR which created the Prometheus instance.
+```
+
+## Steps to Remove MSO
+
+```commandline
+make undeploy-mso 
+// Deletes the MSO CR.
+
+make uninstall-mso
+// Deletes the catalog source and subscription for MSO.
+```


### PR DESCRIPTION
Signed-off-by: Rewant Soni <resoni@redhat.com>

## Description
This PR adds the configuration required for the Monitoring Stack operator and adds a new ServiceMonitor.

## Verification Steps
1. change the project from default to `dbaas-operator`
2. Update the catalog source and subscription to point to the apt image version
3. Install the operator using `make catalog-update-with-mso-install && make deploy-with-mso`
4. Port forward the Prometheus Service as `oc port-forward svc/dbaas-operator-mso-prometheus 28015:9090 -n dbaas-operator`
5. Query the metrics.
![Screenshot from 2022-05-10 16-43-50](https://user-images.githubusercontent.com/18458223/168740011-f23a331d-764a-432b-9eb3-786c887548ef.png)

![Screenshot from 2022-05-17 11-34-36](https://user-images.githubusercontent.com/18458223/168740244-2b9a43f8-252a-4c12-960e-7a90452fd346.png)

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA or in issue number have been completed
- [ ] Unit tests added that prove the fix is effective or the feature works 
- [x] Documentation added for the feature
- [ ] all relevant tests are passing
- [x] Code Review completed
- [ ] Verified independently by reviewer