### PR TITLE
[DBAAS-608] update provider operator versions for 0.2.0 release

### DIFF
--- a/controllers/reconcilers/constants.go
+++ b/controllers/reconcilers/constants.go
@@ -13,8 +13,8 @@ const (
 	CONSOLE_PLUGIN_49_TAG          = "-4.9"
 
 	// CRUNCHY_BRIDGE
-	CRUNCHY_BRIDGE_CATALOG_IMG = "registry.developers.crunchydata.com/crunchydata/crunchy-bridge-operator-catalog:v0.0.4"
-	CRUNCHY_BRIDGE_CSV         = "crunchy-bridge-operator.v0.0.4"
+	CRUNCHY_BRIDGE_CATALOG_IMG = "registry.developers.crunchydata.com/crunchydata/crunchy-bridge-operator-catalog:v0.0.5"
+	CRUNCHY_BRIDGE_CSV         = "crunchy-bridge-operator.v0.0.5"
 	CRUNCHY_BRIDGE_NAME        = "crunchy-bridge"
 	CRUNCHY_BRIDGE_DISPLAYNAME = "Crunchy Bridge Operator"
 	CRUNCHY_BRIDGE_DEPLOYMENT  = "crunchy-bridge-operator-controller-manager"
@@ -31,8 +31,8 @@ const (
 	MONGODB_ATLAS_CHANNEL     = "beta"
 
 	// COCKROACHDB
-	COCKROACHDB_CSV         = "ccapi-k8s-operator.v0.0.2"
-	COCKROACHDB_CATALOG_IMG = "gcr.io/cockroach-shared/ccapi-k8s-operator-catalog:v0.0.2"
+	COCKROACHDB_CSV         = "ccapi-k8s-operator.v0.0.3"
+	COCKROACHDB_CATALOG_IMG = "gcr.io/cockroach-shared/ccapi-k8s-operator-catalog:v0.0.3"
 	COCKROACHDB_NAME        = "ccapi-k8s"
 	COCKROACHDB_DISPLAYNAME = "CockroachDB Cloud Operator"
 	COCKROACHDB_DEPLOYMENT  = "ccapi-k8s-operator-controller-manager"


### PR DESCRIPTION
Signed-off-by: Tommy Hughes <tohughes@redhat.com>

## Description
related to prior change https://github.com/RHEcosystemAppEng/dbaas-operator/pull/186

for 0.2.0 we need the following built into new provider releases
https://github.com/CrunchyData/crunchy-bridge-operator/pull/52
https://github.com/cockroachdb/ccapi-k8s-operator/pull/26