### PR TITLE
DBAAS-738: Move CR name from labels to annotations

### DIFF
--- a/api/v1alpha1/dbaasprovider.go
+++ b/api/v1alpha1/dbaasprovider.go
@@ -41,6 +41,7 @@ const (
 	DBaaSInventoryNotProvisionable string = "DBaaSInventoryNotProvisionable"
 	DBaaSInvalidNamespace          string = "InvalidNamespace"
 	ProviderReconcileInprogress    string = "ProviderReconcileInprogress"
+	ProviderReconcileError         string = "ProviderReconcileError"
 	ProviderParsingError           string = "ProviderParsingError"
 
 	// DBaaS condition messages

--- a/controllers/dbaas_reconciler.go
+++ b/controllers/dbaas_reconciler.go
@@ -208,6 +208,7 @@ func (r *DBaaSReconciler) reconcileProviderResource(providerName string, DBaaSOb
 			return
 		}
 		logger.Error(err, "Error reconciling the Provider resource", "Provider Object", providerObject)
+		*condition = metav1.Condition{Type: DBaaSObjectReadyType, Status: metav1.ConditionFalse, Reason: v1alpha1.ProviderReconcileError, Message: err.Error()}
 		recErr = err
 		return
 	} else if res != controllerutil.OperationResultNone {

--- a/controllers/dbaasconnection_controller.go
+++ b/controllers/dbaasconnection_controller.go
@@ -133,12 +133,14 @@ func (r *DBaaSConnectionReconciler) reconcileDevTopologyResource(connection *v1a
 
 func (r *DBaaSConnectionReconciler) deploymentMutateFn(connection *v1alpha1.DBaaSConnection, deployment *appv1.Deployment) controllerutil.MutateFn {
 	return func() error {
-		deployment.ObjectMeta.Labels = map[string]string{
-			"managed-by":      "dbaas-operator",
-			"owner":           connection.Name,
-			"owner.kind":      connection.Kind,
-			"owner.namespace": connection.Namespace,
+		if deployment.ObjectMeta.Annotations == nil {
+			deployment.ObjectMeta.Annotations = make(map[string]string, 4)
 		}
+		deployment.ObjectMeta.Annotations["managed-by"] = "dbaas-operator"
+		deployment.ObjectMeta.Annotations["owner"] = connection.Name
+		deployment.ObjectMeta.Annotations["owner.kind"] = connection.Kind
+		deployment.ObjectMeta.Annotations["owner.namespace"] = connection.Namespace
+
 		deployment.Spec = appv1.DeploymentSpec{
 			Replicas: pointer.Int32Ptr(0),
 			Selector: &metav1.LabelSelector{


### PR DESCRIPTION
Move CR name from labels to annotations: label value only allows 63 characters while CR name could have 253 characters.

Update CR condition when provider CR creation fails: allow users to know the reason for provider CR creation failure. For example, pass the errors that provider operator validation webhook generates to the DBaaS CR status condition.

## Description
<!-- Please include a summary of the change and link to the related Jira issue. Please add any additional motivation and context as needed. Screenshots are also welcome -->

## Verification Steps
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.
-->

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA or in issue number have been completed
- [ ] Unit tests added that prove the fix is effective or the feature works 
- [ ] Documentation added for the feature
- [ ] all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer