### PR TITLE
[DBAAS-413] remove console-telemetry-plugin from RHODA stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ available to developers for binding to their applications.
 Component |Git Repo	| Description
 ---  | ------ | ----
 DBaaS Console Plugin    |[DBaaS Dynamic Plugin](https://github.com/RHEcosystemAppEng/dbaas-dynamic-plugin) | DBaaS UI console plugin, creation for “Provider Account” and a bindable “Connection” resource.
-OpenShift Console Telemetry Plugin|[Console Telemetry Plugin](https://github.com/RHEcosystemAppEng/console-telemetry-plugin)|An OpenShift Console plugin for tracking user activity such as page changes, property changes, & specific UI events in segment.
 MongoDB Atlas Operator  |[MongoDB Atlas](https://github.com/mongodb/mongodb-atlas-kubernetes) | Operator responsible for establishing API communications with MongoDB Atlas Database.
 Crunchy Bridge Operator |[Crunchy Bridge PostgreSQL](https://github.com/CrunchyData/crunchy-bridge-operator)|Operator responsible for establishing API communications with Crunchy Bridge Managed Postgres Database.
 CockroachCloud Operator |[CockroachCloud Operator](https://github.com/cockroachdb/ccapi-k8s-operator/)|Operator responsible for establishing API communications with CockroachCloud Provider Platform.

--- a/api/v1alpha1/dbaasplatform_types.go
+++ b/api/v1alpha1/dbaasplatform_types.go
@@ -32,14 +32,13 @@ type PlatformsType int
 
 // Supported platforms
 const (
-	CrunchyBridgeInstallation          PlatformsName = "crunchy-bridge"
-	MongoDBAtlasInstallation           PlatformsName = "mongodb-atlas"
-	DBaaSDynamicPluginInstallation     PlatformsName = "dbaas-dynamic-plugin"
-	ConsoleTelemetryPluginInstallation PlatformsName = "console-telemetry-plugin"
-	CockroachDBInstallation            PlatformsName = "cockroachdb-cloud"
-	ObservabilityInstallation          PlatformsName = "observability"
-	DBaaSQuickStartInstallation        PlatformsName = "dbaas-quick-starts"
-	RDSProviderInstallation            PlatformsName = "rds-provider"
+	CrunchyBridgeInstallation      PlatformsName = "crunchy-bridge"
+	MongoDBAtlasInstallation       PlatformsName = "mongodb-atlas"
+	DBaaSDynamicPluginInstallation PlatformsName = "dbaas-dynamic-plugin"
+	CockroachDBInstallation        PlatformsName = "cockroachdb-cloud"
+	ObservabilityInstallation      PlatformsName = "observability"
+	DBaaSQuickStartInstallation    PlatformsName = "dbaas-quick-starts"
+	RDSProviderInstallation        PlatformsName = "rds-provider"
 )
 
 // Platform types

--- a/bundle/manifests/dbaas-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/dbaas-operator.clusterserviceversion.yaml
@@ -444,10 +444,6 @@ spec:
                   value: quay.io/ecosystem-appeng/dbaas-dynamic-plugin:0.3.0
                 - name: CSV_VERSION_DBAAS_DYNAMIC_PLUGIN
                   value: dbaas-dynamic-plugin:0.3.0
-                - name: RELATED_IMAGE_CONSOLE_TELEMETRY_PLUGIN
-                  value: quay.io/ecosystem-appeng/console-telemetry-plugin:0.1.4
-                - name: CSV_VERSION_CONSOLE_TELEMETRY_PLUGIN
-                  value: console-telemetry-plugin:0.1.4
                 - name: RELATED_IMAGE_OBSERVABILITY_CATALOG
                   value: quay.io/rhobs/observability-operator-catalog:0.0.13
                 - name: CSV_VERSION_OBSERVABILITY
@@ -599,8 +595,6 @@ spec:
   relatedImages:
   - image: quay.io/ecosystem-appeng/dbaas-dynamic-plugin:0.3.0
     name: dbaas-dynamic-plugin
-  - image: quay.io/ecosystem-appeng/console-telemetry-plugin:0.1.4
-    name: console-telemetry-plugin
   - image: quay.io/rhobs/observability-operator-catalog:0.0.13
     name: observability-catalog
   - image: registry.developers.crunchydata.com/crunchydata/crunchy-bridge-operator-catalog:v0.0.5

--- a/config/default/manager-env-images.yaml
+++ b/config/default/manager-env-images.yaml
@@ -14,10 +14,6 @@ spec:
           value: quay.io/ecosystem-appeng/dbaas-dynamic-plugin:0.3.0
         - name: CSV_VERSION_DBAAS_DYNAMIC_PLUGIN
           value: dbaas-dynamic-plugin:0.3.0
-        - name: RELATED_IMAGE_CONSOLE_TELEMETRY_PLUGIN
-          value: quay.io/ecosystem-appeng/console-telemetry-plugin:0.1.4
-        - name: CSV_VERSION_CONSOLE_TELEMETRY_PLUGIN
-          value: console-telemetry-plugin:0.1.4
         - name: RELATED_IMAGE_OBSERVABILITY_CATALOG
           value: quay.io/rhobs/observability-operator-catalog:0.0.13
         - name: CSV_VERSION_OBSERVABILITY

--- a/controllers/dbaasplatform_controller.go
+++ b/controllers/dbaasplatform_controller.go
@@ -48,20 +48,17 @@ Platform resources to be created or updated explicitly by the DBaaS operator:
 	MongoDB Atlas operator: CatalogSource, Subscription, OperatorGroup
 	Service Binding operator: Subscription
 	DBaaS Dynamic Plugin: Service, Deployment, ConsolePlugin, Console (updated)
-	Console Telemetry Plugin: Service, Deployment, ConsolePlugin, Console (updated)
 
 Platform resources to be removed by the DBaaS operator by setting owner reference:
 	Crunchy Bridge operator: Subscription, CSV
 	MongoDB Atlas operator: Subscription, CSV
 	Service Binding operator: Subscription, CSV
 	DBaaS Dynamic Plugin: Service, Deployment
-	Console Telemetry Plugin: Service, Deployment
 
 Platform resources NOT to be removed or updated by the DBaaS operator:
 	Crunchy Bridge operator: CatalogSource (in different namespace), OperatorGroup (in different namespace)
 	MongoDB Atlas operator: CatalogSource (in different namespace), OperatorGroup (in different namespace)
 	DBaaS Dynamic Plugin: ConsolePlugin (cluster-scoped), Console (cluster-scoped)
-	Console Telemetry Plugin: ConsolePlugin (cluster-scoped), Console (cluster-scoped)
 */
 
 // Constants for requeue

--- a/controllers/reconcilers/constants.go
+++ b/controllers/reconcilers/constants.go
@@ -52,14 +52,6 @@ const (
 	dbaasDynamicPluginName        = "dbaas-dynamic-plugin"
 	dbaasDynamicPluginDisplayName = "OpenShift Database as a Service Dynamic Plugin"
 
-	// CONSOLE_TELEMETRY_PLUGIN
-	consoleTelemetryPluginImg           = "RELATED_IMAGE_CONSOLE_TELEMETRY_PLUGIN"
-	consoleTelemetryPluginVersion       = "CSV_VERSION_CONSOLE_TELEMETRY_PLUGIN"
-	consoleTelemetryPluginName          = "console-telemetry-plugin"
-	consoleTelemetryPluginDisplayName   = "Telemetry Plugin"
-	consoleTelemetryPluginSegmentKeyEnv = "SEGMENT_KEY"
-	consoleTelemetryPluginSegmentKey    = "qejcCDG37ICCLIDsM1FcJDkd68hglCoK"
-
 	// RDS_PROVIDER
 	rdsProviderCSV         = "CSV_VERSION_RDS_PROVIDER"
 	rdsProviderCatalogImg  = "RELATED_IMAGE_RDS_PROVIDER_CATALOG"
@@ -86,14 +78,6 @@ var InstallationPlatforms = map[dbaasv1alpha1.PlatformsName]dbaasv1alpha1.Platfo
 		CSV:         fetchEnvValue(dbaasDynamicPluginVersion),
 		Image:       fetchEnvValue(dbaasDynamicPluginImg),
 		DisplayName: dbaasDynamicPluginDisplayName,
-		Type:        dbaasv1alpha1.TypeConsolePlugin,
-	},
-	dbaasv1alpha1.ConsoleTelemetryPluginInstallation: {
-		Name:        consoleTelemetryPluginName,
-		CSV:         fetchEnvValue(consoleTelemetryPluginVersion),
-		Image:       fetchEnvValue(consoleTelemetryPluginImg),
-		DisplayName: consoleTelemetryPluginDisplayName,
-		Envs:        []corev1.EnvVar{{Name: consoleTelemetryPluginSegmentKeyEnv, Value: consoleTelemetryPluginSegmentKey}},
 		Type:        dbaasv1alpha1.TypeConsolePlugin,
 	},
 	dbaasv1alpha1.CrunchyBridgeInstallation: {


### PR DESCRIPTION
console-telemetry-plugin is no longer in use and should be removed from the project now.

Signed-off-by: Tommy Hughes <tohughes@redhat.com>