### PR TITLE
[DBAAS-771] further harden deployment scc

### DIFF
--- a/bundle/manifests/dbaas-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/dbaas-operator.clusterserviceversion.yaml
@@ -433,6 +433,7 @@ spec:
                     drop:
                     - ALL
                   readOnlyRootFilesystem: true
+                  runAsNonRoot: true
               - args:
                 - --health-probe-bind-address=:8081
                 - --metrics-bind-address=0.0.0.0:8080
@@ -536,8 +537,7 @@ spec:
                     drop:
                     - ALL
                   readOnlyRootFilesystem: true
-              securityContext:
-                runAsNonRoot: true
+                  runAsNonRoot: true
               serviceAccountName: dbaas-operator-controller-manager
               terminationGracePeriodSeconds: 10
       permissions:

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -22,6 +22,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+          runAsNonRoot: true
           capabilities:
             drop:
             - ALL

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -24,8 +24,6 @@ spec:
         control-plane: controller-manager
         type: dbaas-operator
     spec:
-      securityContext:
-        runAsNonRoot: true
       containers:
       - command:
         - /manager
@@ -38,6 +36,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+          runAsNonRoot: true
           capabilities:
             drop:
             - ALL

--- a/controllers/reconcilers/consoleplugin/plugin_installation_reconciler.go
+++ b/controllers/reconcilers/consoleplugin/plugin_installation_reconciler.go
@@ -202,6 +202,8 @@ func (r *reconciler) reconcileDeployment(ctx context.Context, cr *v1alpha1.DBaaS
 					Capabilities: &v1.Capabilities{
 						Drop: []v1.Capability{"ALL"},
 					},
+					ReadOnlyRootFilesystem: &ptrTrue,
+					RunAsNonRoot:           &ptrTrue,
 				},
 				LivenessProbe: &v1.Probe{
 					ProbeHandler:        socketHandler,
@@ -213,9 +215,6 @@ func (r *reconciler) reconcileDeployment(ctx context.Context, cr *v1alpha1.DBaaS
 					PeriodSeconds:       20,
 				},
 			},
-		}
-		deployment.Spec.Template.Spec.SecurityContext = &v1.PodSecurityContext{
-			RunAsNonRoot: &ptrTrue,
 		}
 		deployment.Spec.Template.Spec.Volumes = []v1.Volume{
 			{


### PR DESCRIPTION
add `readOnlyRootFilesystem: true` to console deployment. consolidate all scc settings to containers.

Signed-off-by: Tommy Hughes <tohughes@redhat.com>