### PR TITLE
Fix DBaaSConnecton webhook ValidateUpdate crash

### DIFF
--- a/api/v1alpha1/dbaasconnection_webhook.go
+++ b/api/v1alpha1/dbaasconnection_webhook.go
@@ -58,7 +58,7 @@ func (r *DBaaSConnection) ValidateDelete() error {
 	return nil
 }
 
-func (r *DBaaSConnection) validateUpdateDBaaSConnectionSpec(old *DBaaSConnection) *field.Error {
+func (r *DBaaSConnection) validateUpdateDBaaSConnectionSpec(old *DBaaSConnection) error {
 	if r.Spec.InstanceID != old.Spec.InstanceID {
 		return field.Invalid(field.NewPath("spec").Child("instanceID"), r.Spec.InstanceID, "instanceID is immutable")
 	}


### PR DESCRIPTION
This PR provides a fix for the issue https://issues.redhat.com/browse/DBAAS-852 (DBaasConnection webhook fails when a CR is updated without spec changes).

The DBaaS Operator  log has the following error
tform", "name": "dbaas-platform", "namespace": "openshift-dbaas-operator", "working platform": "dbaas-dynamic-plugin"}
1.6614549767692513e+09	INFO	dbaasinventory-resource	validate update	{"name": "myinventory2"}
1.661454982158885e+09	INFO	dbaasconnection-resource	validate update	{"name": "myconnection2"}
2022/08/25 19:16:22 http: panic serving 10.130.0.1:39032: runtime error: invalid memory address or nil pointer dereference
goroutine 1580 [running]:
net/http.(*conn).serve.func1()
	/usr/lib/golang/src/net/http/server.go:1802 +0xb9
panic({0x1648a60, 0x278cb40})
	/usr/lib/golang/src/runtime/panic.go:1047 +0x266
k8s.io/apimachinery/pkg/util/validation/field.(*Error).ErrorBody(0x0)
	/opt/app-root/src/go/pkg/mod/k8s.io/apimachinery@v0.23.5/pkg/util/validation/field/errors.go:49 +0x2e
k8s.io/apimachinery/pkg/util/validation/field.(*Error).Error(0x0)
	/opt/app-root/src/go/pkg/mod/k8s.io/apimachinery@v0.23.5/pkg/util/validation/field/errors.go:42 +0x25
sigs.k8s.io/controller-runtime/pkg/webhook/admission.(*validatingHandler).Handle(_, {_, _}, {{{0xc000e48240, 0x24}, {{0xc0014390f0, 0x10}, {0xc0014390c8, 0x8}, {0xc001439100, ...}}, ...}})
	/opt/app-root/src/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.11.2/pkg/webhook/admission/validator.go:99 +0x942
sigs.k8s.io/controller-runtime/pkg/webhook/admission.(*Webhook).Handle(_, {_, _}, {{{0xc000e48240, 0x24}, {{0xc0014390f0, 0x10}, {0xc0014390c8, 0x8}, {0xc001439100, ...}}, ...}})
	/opt/app-root/src/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.11.2/pkg/webhook/admission/webhook.go:146 +0xa2
sigs.k8s.io/controller-runtime/pkg/webhook/admission.(*Webhook).ServeHTTP(0xc0007bcd00, {0x7f6d04f426c0, 0xc000e74eb0}, 0xc000b2b700)
	/opt/app-root/src/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.11.2/pkg/webhook/admission/http.go:99 +0xef6
github.com/prometheus/client_golang/prometheus/promhttp.InstrumentHandlerInFlight.func1({0x7f6d04f426c0, 0xc000e74eb0}, 0xc000e74eb0)
	/opt/app-root/src/go/pkg/mod/github.com/prometheus/client_golang@v1.11.0/prometheus/promhttp/instrument_server.go:40 +0xd4
net/http.HandlerFunc.ServeHTTP(0x1a7d048, {0x7f6d04f426c0, 0xc000e74eb0}, 0x3)
	/usr/lib/golang/src/net/http/server.go:2047 +0x2f
github.com/prometheus/client_golang/prometheus/promhttp.InstrumentHandlerCounter.func1({0x1a7d048, 0xc000caba40}, 0xc000b2b700)
	/opt/app-root/src/go/pkg/mod/github.com/prometheus/client_golang@v1.11.0/prometheus/promhttp/instrument_server.go:101 +0x92
net/http.HandlerFunc.ServeHTTP(0xc0007bcd80, {0x1a7d048, 0xc000caba40}, 0x203000)
	/usr/lib/golang/src/net/http/server.go:2047 +0x2f
github.com/prometheus/client_golang/prometheus/promhttp.InstrumentHandlerDuration.func2({0x1a7d048, 0xc000caba40}, 0xc000b2b700)
	/opt/app-root/src/go/pkg/mod/github.com/prometheus/client_golang@v1.11.0/prometheus/promhttp/instrument_server.go:76 +0xa2
net/http.HandlerFunc.ServeHTTP(0xc0ba1081896a687b, {0x1a7d048, 0xc000caba40}, 0xc000caba40)
	/usr/lib/golang/src/net/http/server.go:2047 +0x2f
net/http.(*ServeMux).ServeHTTP(0xc001478b79, {0x1a7d048, 0xc000caba40}, 0xc000b2b700)
	/usr/lib/golang/src/net/http/server.go:2425 +0x149
net/http.serverHandler.ServeHTTP({0x1a70550}, {0x1a7d048, 0xc000caba40}, 0xc000b2b700)
	/usr/lib/golang/src/net/http/server.go:2879 +0x43b
net/http.(*conn).serve(0xc00146d720, {0x1a81f98, 0xc0003fb200})
	/usr/lib/golang/src/net/http/server.go:1930 +0xb08
created by net/http.(*Server).Serve
	/usr/lib/golang/src/net/http/server.go:3034 +0x4e8

## Verification Steps
1) Create a DBaaSConnection CR myconnection.
2) Edit the CR and add a label to the CR and then save.
oc edit DBaaSConnection myconnection
3) The edit should succceed.
## Type of change
<!-- Please delete options that are not relevant. -->
- [ X] Bug fix (non-breaking change which fixes an issue)

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [X ] All acceptance criteria specified in JIRA or in issue number have been completed
- [ ] Unit tests added that prove the fix is effective or the feature works 
- [ ] Documentation added for the feature
- [ X] all relevant tests are passing
- [ X] Code Review completed
- [ X] Verified independently by reviewer