### PR TITLE
Enhance DBaaS Operator to have human-readable timestamps in the logs

### DIFF
--- a/main.go
+++ b/main.go
@@ -106,6 +106,7 @@ func main() {
 	opts := zap.Options{
 		Development: true,
 		Level:       level,
+		TimeEncoder: zapcore.ISO8601TimeEncoder,
 	}
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()


### PR DESCRIPTION
## Description
The existing DBaaS Operator logs uses epoch timestamps:
1.661370375316567e+09	INFO	The Operator is watching the namespace 
1.6613703753166752e+09	INFO	MongoDB Atlas Operator version v0.6.1-92-g2640489-dirty
They are not easy to read.

This PR changes the timestamps to UTC so that it is readable and easier for troubleshooting.

## Verification Steps
Check the operator logs for timestamp format:
2022-08-25T21:39:48.717Z	INFO	controller-runtime.metrics	Metrics server is starting to listen	{"addr": "0.0.0.0:8080"}
2022-08-25T21:39:48.717Z	INFO	controller-runtime.builder	skip registering a mutating webhook, object does not implement admission.Defaulter or WithDefaulter wasn't called	{"GVK": "dbaas.redhat.com/v1alpha1, Kind=DBaaSConnection"}
2022-08-25T21:39:48.717Z	INFO	controller-runtime.builder	Registering a validating webhook	{"GVK": "dbaas.redhat.com/v1alpha1, Kind=DBaaSConnection", "path": "/validate-dbaas-redhat-com-v1alpha1-dbaasconnection"}
2022-08-25T21:39:48.718Z	INFO	controller-runtime.webhook	Registering webhook	{"path": "/validate-dbaas-redhat-com-v1alpha1-dbaasconnection"}
2022-08-25T21:39:48.718Z	INFO	controller-runtime.builder
## Type of change
<!-- Please delete options that are not relevant. -->
- [X] New feature (non-breaking change which adds functionality)

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [X ] All acceptance criteria specified in JIRA or in issue number have been completed
- [ ] Unit tests added that prove the fix is effective or the feature works 
- [ ] Documentation added for the feature
- [X ] all relevant tests are passing
- [ X] Code Review completed
- [X ] Verified independently by reviewer