### PR TITLE
[DBAAS-887] add selector option for valid DBaaS Connection/Instance namespaces

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.16.x
+          go-version: 1.17.x
       - name: Install goimports
         run: go install golang.org/x/tools/cmd/goimports@v0.1.11
       - name: Checkout code

--- a/api/v1alpha1/dbaasinventory_webhook.go
+++ b/api/v1alpha1/dbaasinventory_webhook.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -97,6 +98,12 @@ func validateInventory(inv *DBaaSInventory, oldInv *DBaaSInventory) error {
 	// Check RDS
 	if oldInv == nil && inv.Spec.ProviderRef.Name == rdsRegistration {
 		if err := validateRDS(); err != nil {
+			return err
+		}
+	}
+	// Check ns selector
+	if inv.Spec.ConnectionNsSelector != nil {
+		if _, err := metav1.LabelSelectorAsSelector(inv.Spec.ConnectionNsSelector); err != nil {
 			return err
 		}
 	}

--- a/api/v1alpha1/dbaaspolicy_types.go
+++ b/api/v1alpha1/dbaaspolicy_types.go
@@ -34,7 +34,13 @@ type DBaaSInventoryPolicy struct {
 	// Namespaces where DBaaSConnections/DBaaSInstances are allowed to reference a policy's inventories.
 	// Each inventory can individually override this. Use "*" to allow all namespaces.
 	// If not set in either the policy or inventory object, connections will only be allowed in the inventory's namespace.
-	ConnectionNamespaces []string `json:"connectionNamespaces,omitempty"`
+	ConnectionNamespaces *[]string `json:"connectionNamespaces,omitempty"`
+
+	// Use a label selector to determine namespaces where DBaaSConnections/DBaaSInstances are allowed to reference a policy's inventories.
+	// Each inventory can individually override this. A label selector is a label query over a set of resources. The result of matchLabels and
+	// matchExpressions are ANDed. An empty label selector matches all objects. A null
+	// label selector matches no objects.
+	ConnectionNsSelector *metav1.LabelSelector `json:"connectionNsSelector,omitempty"`
 }
 
 // DBaaSPolicyStatus defines the observed state of DBaaSPolicy

--- a/api/v1alpha1/dbaaspolicy_webhook.go
+++ b/api/v1alpha1/dbaaspolicy_webhook.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2021.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+)
+
+// log is for logging in this package.
+var dbaaspolicylog = logf.Log.WithName("dbaaspolicy-resource")
+
+// SetupWebhookWithManager sets up the webhook with the Manager.
+func (r *DBaaSPolicy) SetupWebhookWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewWebhookManagedBy(mgr).
+		For(r).
+		Complete()
+}
+
+//+kubebuilder:webhook:path=/validate-dbaas-redhat-com-v1alpha1-dbaaspolicy,mutating=false,failurePolicy=fail,sideEffects=None,groups=dbaas.redhat.com,resources=dbaaspolicies,verbs=create;update,versions=v1alpha1,name=vdbaaspolicy.kb.io,admissionReviewVersions=v1
+
+var _ webhook.Validator = &DBaaSPolicy{}
+
+// ValidateCreate implements webhook.Validator so a webhook will be registered for the type
+func (r *DBaaSPolicy) ValidateCreate() error {
+	dbaaspolicylog.Info("validate create", "name", r.Name)
+	return validatePolicy(r)
+}
+
+// ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
+func (r *DBaaSPolicy) ValidateUpdate(_ runtime.Object) error {
+	dbaaspolicylog.Info("validate update", "name", r.Name)
+	return validatePolicy(r)
+}
+
+// ValidateDelete implements webhook.Validator so a webhook will be registered for the type
+func (r *DBaaSPolicy) ValidateDelete() error {
+	dbaaspolicylog.Info("validate delete", "name", r.Name)
+	return nil
+}
+
+func validatePolicy(policy *DBaaSPolicy) error {
+	// Check ns selector
+	if policy.Spec.ConnectionNsSelector != nil {
+		if _, err := metav1.LabelSelectorAsSelector(policy.Spec.ConnectionNsSelector); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/api/v1alpha1/dbaaspolicy_webhook_test.go
+++ b/api/v1alpha1/dbaaspolicy_webhook_test.go
@@ -1,0 +1,86 @@
+/*
+Copyright 2021, Red Hat.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var (
+	testDBaaSPolicy = DBaaSPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "testpolicy",
+			Namespace: testNamespace,
+		},
+	}
+)
+
+var _ = Describe("DBaaSPolicy Webhook", func() {
+	Context("creation fails",
+		func() {
+			It("missing required values field", func() {
+				inv := testDBaaSPolicy.DeepCopy()
+				inv.SetResourceVersion("")
+				inv.Spec = DBaaSPolicySpec{
+					DBaaSInventoryPolicy: DBaaSInventoryPolicy{
+						ConnectionNsSelector: &metav1.LabelSelector{
+							MatchExpressions: []metav1.LabelSelectorRequirement{{Key: "test", Operator: "In"}},
+						},
+					},
+				}
+				err := k8sClient.Create(ctx, inv)
+				Expect(err).Should(MatchError("admission webhook \"vdbaaspolicy.kb.io\" denied the request: values: Invalid value: []string(nil): for 'in', 'notin' operators, values set can't be empty"))
+			})
+		})
+	Context("without optional fields", func() {
+		It("should succeed without optional fields", func() {
+			testDBaaSPolicy.SetResourceVersion("")
+			err := k8sClient.Create(ctx, &testDBaaSPolicy)
+			Expect(err).Should(BeNil())
+		})
+	})
+	Context("update",
+		func() {
+			Context("nominal", func() {
+				It("Update CR should succeed", func() {
+					inv := testDBaaSPolicy.DeepCopy()
+					Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(inv), inv)).Should(Succeed())
+					inv.Spec = DBaaSPolicySpec{
+						DBaaSInventoryPolicy: DBaaSInventoryPolicy{
+							ConnectionNsSelector: &metav1.LabelSelector{
+								MatchExpressions: []metav1.LabelSelectorRequirement{{Key: "test", Operator: "In", Values: []string{"blah"}}},
+							},
+						},
+					}
+					err := k8sClient.Update(ctx, inv)
+					Expect(err).Should(BeNil())
+				})
+			})
+			Context("update fails", func() {
+				It("update fails with missing required values field", func() {
+					inv := testDBaaSPolicy.DeepCopy()
+					Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(inv), inv)).Should(Succeed())
+					inv.Spec.ConnectionNsSelector.MatchExpressions = []metav1.LabelSelectorRequirement{{Key: "test", Operator: "In"}}
+					err := k8sClient.Update(ctx, inv)
+					Expect(err).Should(MatchError("admission webhook \"vdbaaspolicy.kb.io\" denied the request: values: Invalid value: []string(nil): for 'in', 'notin' operators, values set can't be empty"))
+				})
+			})
+		})
+})

--- a/api/v1alpha1/webhook_suite_test.go
+++ b/api/v1alpha1/webhook_suite_test.go
@@ -118,6 +118,9 @@ var _ = BeforeSuite(func() {
 	err = (&DBaaSInventory{}).SetupWebhookWithManager(mgr)
 	Expect(err).NotTo(HaveOccurred())
 
+	err = (&DBaaSPolicy{}).SetupWebhookWithManager(mgr)
+	Expect(err).NotTo(HaveOccurred())
+
 	ns2 := corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: testNamespace2,

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -334,8 +334,17 @@ func (in *DBaaSInventoryPolicy) DeepCopyInto(out *DBaaSInventoryPolicy) {
 	}
 	if in.ConnectionNamespaces != nil {
 		in, out := &in.ConnectionNamespaces, &out.ConnectionNamespaces
-		*out = make([]string, len(*in))
-		copy(*out, *in)
+		*out = new([]string)
+		if **in != nil {
+			in, out := *in, *out
+			*out = make([]string, len(*in))
+			copy(*out, *in)
+		}
+	}
+	if in.ConnectionNsSelector != nil {
+		in, out := &in.ConnectionNsSelector, &out.ConnectionNsSelector
+		*out = new(metav1.LabelSelector)
+		(*in).DeepCopyInto(*out)
 	}
 }
 

--- a/bundle/manifests/dbaas-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/dbaas-operator.clusterserviceversion.yaml
@@ -298,6 +298,14 @@ spec:
         - apiGroups:
           - ""
           resources:
+          - namespaces
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
           - resourcequotas
           verbs:
           - create
@@ -637,3 +645,23 @@ spec:
     targetPort: 9443
     type: ValidatingAdmissionWebhook
     webhookPath: /validate-dbaas-redhat-com-v1alpha1-dbaasinventory
+  - admissionReviewVersions:
+    - v1
+    containerPort: 443
+    deploymentName: dbaas-operator-controller-manager
+    failurePolicy: Fail
+    generateName: vdbaaspolicy.kb.io
+    rules:
+    - apiGroups:
+      - dbaas.redhat.com
+      apiVersions:
+      - v1alpha1
+      operations:
+      - CREATE
+      - UPDATE
+      resources:
+      - dbaaspolicies
+    sideEffects: None
+    targetPort: 9443
+    type: ValidatingAdmissionWebhook
+    webhookPath: /validate-dbaas-redhat-com-v1alpha1-dbaaspolicy

--- a/bundle/manifests/dbaas.redhat.com_dbaasinventories.yaml
+++ b/bundle/manifests/dbaas.redhat.com_dbaasinventories.yaml
@@ -45,6 +45,55 @@ spec:
                 items:
                   type: string
                 type: array
+              connectionNsSelector:
+                description: Use a label selector to determine namespaces where DBaaSConnections/DBaaSInstances
+                  are allowed to reference a policy's inventories. Each inventory
+                  can individually override this. A label selector is a label query
+                  over a set of resources. The result of matchLabels and matchExpressions
+                  are ANDed. An empty label selector matches all objects. A null label
+                  selector matches no objects.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that
+                        contains values, a key, and an operator that relates the key
+                        and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to
+                            a set of values. Valid operators are In, NotIn, Exists
+                            and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the
+                            operator is In or NotIn, the values array must be non-empty.
+                            If the operator is Exists or DoesNotExist, the values
+                            array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single
+                      {key,value} in the matchLabels map is equivalent to an element
+                      of matchExpressions, whose key field is "key", the operator
+                      is "In", and the values array contains only "value". The requirements
+                      are ANDed.
+                    type: object
+                type: object
               credentialsRef:
                 description: The Secret containing the provider-specific connection
                   credentials to use with its API endpoint. The format of the Secret

--- a/bundle/manifests/dbaas.redhat.com_dbaaspolicies.yaml
+++ b/bundle/manifests/dbaas.redhat.com_dbaaspolicies.yaml
@@ -54,6 +54,55 @@ spec:
                 items:
                   type: string
                 type: array
+              connectionNsSelector:
+                description: Use a label selector to determine namespaces where DBaaSConnections/DBaaSInstances
+                  are allowed to reference a policy's inventories. Each inventory
+                  can individually override this. A label selector is a label query
+                  over a set of resources. The result of matchLabels and matchExpressions
+                  are ANDed. An empty label selector matches all objects. A null label
+                  selector matches no objects.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that
+                        contains values, a key, and an operator that relates the key
+                        and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to
+                            a set of values. Valid operators are In, NotIn, Exists
+                            and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the
+                            operator is In or NotIn, the values array must be non-empty.
+                            If the operator is Exists or DoesNotExist, the values
+                            array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single
+                      {key,value} in the matchLabels map is equivalent to an element
+                      of matchExpressions, whose key field is "key", the operator
+                      is "In", and the values array contains only "value". The requirements
+                      are ANDed.
+                    type: object
+                type: object
               disableProvisions:
                 description: Disable provisioning against inventory accounts
                 type: boolean

--- a/config/crd/bases/dbaas.redhat.com_dbaasinventories.yaml
+++ b/config/crd/bases/dbaas.redhat.com_dbaasinventories.yaml
@@ -47,6 +47,55 @@ spec:
                 items:
                   type: string
                 type: array
+              connectionNsSelector:
+                description: Use a label selector to determine namespaces where DBaaSConnections/DBaaSInstances
+                  are allowed to reference a policy's inventories. Each inventory
+                  can individually override this. A label selector is a label query
+                  over a set of resources. The result of matchLabels and matchExpressions
+                  are ANDed. An empty label selector matches all objects. A null label
+                  selector matches no objects.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that
+                        contains values, a key, and an operator that relates the key
+                        and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to
+                            a set of values. Valid operators are In, NotIn, Exists
+                            and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the
+                            operator is In or NotIn, the values array must be non-empty.
+                            If the operator is Exists or DoesNotExist, the values
+                            array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single
+                      {key,value} in the matchLabels map is equivalent to an element
+                      of matchExpressions, whose key field is "key", the operator
+                      is "In", and the values array contains only "value". The requirements
+                      are ANDed.
+                    type: object
+                type: object
               credentialsRef:
                 description: The Secret containing the provider-specific connection
                   credentials to use with its API endpoint. The format of the Secret

--- a/config/crd/bases/dbaas.redhat.com_dbaaspolicies.yaml
+++ b/config/crd/bases/dbaas.redhat.com_dbaaspolicies.yaml
@@ -56,6 +56,55 @@ spec:
                 items:
                   type: string
                 type: array
+              connectionNsSelector:
+                description: Use a label selector to determine namespaces where DBaaSConnections/DBaaSInstances
+                  are allowed to reference a policy's inventories. Each inventory
+                  can individually override this. A label selector is a label query
+                  over a set of resources. The result of matchLabels and matchExpressions
+                  are ANDed. An empty label selector matches all objects. A null label
+                  selector matches no objects.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that
+                        contains values, a key, and an operator that relates the key
+                        and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to
+                            a set of values. Valid operators are In, NotIn, Exists
+                            and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the
+                            operator is In or NotIn, the values array must be non-empty.
+                            If the operator is Exists or DoesNotExist, the values
+                            array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single
+                      {key,value} in the matchLabels map is equivalent to an element
+                      of matchExpressions, whose key field is "key", the operator
+                      is "In", and the values array contains only "value". The requirements
+                      are ANDed.
+                    type: object
+                type: object
               disableProvisions:
                 description: Disable provisioning against inventory accounts
                 type: boolean

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -74,6 +74,14 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - resourcequotas
   verbs:
   - create

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -46,3 +46,23 @@ webhooks:
     resources:
     - dbaasinventories
   sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-dbaas-redhat-com-v1alpha1-dbaaspolicy
+  failurePolicy: Fail
+  name: vdbaaspolicy.kb.io
+  rules:
+  - apiGroups:
+    - dbaas.redhat.com
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - dbaaspolicies
+  sideEffects: None

--- a/controllers/dbaasdefaultpolicy_controller.go
+++ b/controllers/dbaasdefaultpolicy_controller.go
@@ -118,7 +118,7 @@ func getDefaultPolicy(inventoryNamespace string) v1alpha1.DBaaSPolicy {
 		},
 		Spec: v1alpha1.DBaaSPolicySpec{
 			DBaaSInventoryPolicy: v1alpha1.DBaaSInventoryPolicy{
-				ConnectionNamespaces: []string{"*"},
+				ConnectionNamespaces: &[]string{"*"},
 			},
 		},
 	}

--- a/controllers/dbaasinstance_controller_test.go
+++ b/controllers/dbaasinstance_controller_test.go
@@ -141,7 +141,7 @@ var _ = Describe("DBaaSInstance controller with errors", func() {
 					Name: testProviderName,
 				},
 				DBaaSInventoryPolicy: v1alpha1.DBaaSInventoryPolicy{
-					ConnectionNamespaces: []string{"valid-ns", "random"},
+					ConnectionNamespaces: &[]string{"valid-ns", "random"},
 				},
 				DBaaSInventorySpec: *DBaaSInventorySpec,
 			},
@@ -339,7 +339,7 @@ var _ = Describe("DBaaSInstance controller - valid dev namespaces", func() {
 						Name: testProviderName,
 					},
 					DBaaSInventoryPolicy: v1alpha1.DBaaSInventoryPolicy{
-						ConnectionNamespaces: []string{otherNS.Name},
+						ConnectionNamespaces: &[]string{otherNS.Name},
 					},
 					DBaaSInventorySpec: v1alpha1.DBaaSInventorySpec{
 						CredentialsRef: &v1alpha1.LocalObjectReference{
@@ -453,7 +453,7 @@ var _ = Describe("DBaaSInstance controller - valid dev namespaces", func() {
 						Name: testProviderName,
 					},
 					DBaaSInventoryPolicy: v1alpha1.DBaaSInventoryPolicy{
-						ConnectionNamespaces: []string{"*"},
+						ConnectionNamespaces: &[]string{"*"},
 					},
 					DBaaSInventorySpec: v1alpha1.DBaaSInventorySpec{
 						CredentialsRef: &v1alpha1.LocalObjectReference{
@@ -568,7 +568,7 @@ var _ = Describe("DBaaSInstance controller - valid dev namespaces", func() {
 						Name: testProviderName,
 					},
 					DBaaSInventoryPolicy: v1alpha1.DBaaSInventoryPolicy{
-						ConnectionNamespaces: []string{"*"},
+						ConnectionNamespaces: &[]string{"*"},
 						DisableProvisions:    &isTrue,
 					},
 					DBaaSInventorySpec: v1alpha1.DBaaSInventorySpec{

--- a/controllers/dbaaspolicy_controller.go
+++ b/controllers/dbaaspolicy_controller.go
@@ -39,6 +39,7 @@ type DBaaSPolicyReconciler struct {
 //+kubebuilder:rbac:groups=dbaas.redhat.com,resources=*/finalizers,verbs=update
 //+kubebuilder:rbac:groups=core,resources=resourcequotas,verbs=get;list;create;update;watch
 //+kubebuilder:rbac:groups=core,resources=resourcequotas/finalizers,verbs=update
+//+kubebuilder:rbac:groups=core,resources=namespaces,verbs=get;list;watch
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/controllers/metrics.go
+++ b/controllers/metrics.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 
-	"github.com/RHEcosystemAppEng/dbaas-operator/api/v1alpha1"
 	dbaasv1alpha1 "github.com/RHEcosystemAppEng/dbaas-operator/api/v1alpha1"
 )
 
@@ -248,7 +247,7 @@ func setConnectionStatusMetrics(provider string, account string, connection dbaa
 }
 
 // setConnectionRequestDurationSeconds set the metrics for connection request duration in seconds
-func setConnectionRequestDurationSeconds(provider string, account string, connection v1alpha1.DBaaSConnection, execution Execution) {
+func setConnectionRequestDurationSeconds(provider string, account string, connection dbaasv1alpha1.DBaaSConnection, execution Execution) {
 	httpDuration := time.Since(execution.begin)
 	for _, cond := range connection.Status.Conditions {
 		if cond.Type == dbaasv1alpha1.DBaaSConnectionProviderSyncType {
@@ -303,7 +302,7 @@ func setInstanceStatusMetrics(provider string, account string, instance dbaasv1a
 }
 
 // setInstanceRequestDurationSeconds set the metrics for instance request duration in seconds
-func setInstanceRequestDurationSeconds(provider string, account string, instance v1alpha1.DBaaSInstance, execution Execution) {
+func setInstanceRequestDurationSeconds(provider string, account string, instance dbaasv1alpha1.DBaaSInstance, execution Execution) {
 	httpDuration := time.Since(execution.begin)
 	for _, cond := range instance.Status.Conditions {
 		if cond.Type == dbaasv1alpha1.DBaaSInstanceProviderSyncType {

--- a/main.go
+++ b/main.go
@@ -185,6 +185,10 @@ func main() {
 			setupLog.Error(err, "unable to create webhook", "webhook", "DBaaSInventory")
 			os.Exit(1)
 		}
+		if err = (&v1alpha1.DBaaSPolicy{}).SetupWebhookWithManager(mgr); err != nil {
+			setupLog.Error(err, "unable to create webhook", "webhook", "DBaaSPolicy")
+			os.Exit(1)
+		}
 	}
 	if err = (&controllers.DBaaSPolicyReconciler{
 		DBaaSReconciler: DBaaSReconciler,


### PR DESCRIPTION
Signed-off-by: Tommy Hughes <tohughes@redhat.com>

## Description
Support for setting namespace [label selectors](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/). The following can be set in policy and/or inventory objects.
```yaml
spec:
  connectionNsSelector:
    matchExpressions:
      - key: test
        operator: NotIn
        values:
          - production
    matchLabels:
    - foo: one
    - two: bar
```