### PR TITLE
[DBAAS-975] add coverage check action

### DIFF
--- a/.github/workflows/gotest.yml
+++ b/.github/workflows/gotest.yml
@@ -18,7 +18,45 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: 1.17.x
+
       - name: Checkout code
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
       - name: Unit tests
         run: make test
+
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v33
+
+      - name: List all changed files
+        run: |
+          touch cover.files.out
+          for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
+            echo "$file" >> cover.files.out
+          done
+
+      - name: Quality Gate - test coverage for modified files shall be above 70%
+        env:
+          TESTCOVERAGE_THRESHOLD: 70
+        run: |
+          cat cover.tmp.out | grep -v "_generated.*.go" > cover.tmp2.out
+          head -n 1 cover.tmp2.out > cover.out
+          grep -f cover.files.out cover.tmp2.out >> cover.out || true
+          if [ $(cat cover.out | wc -l) -gt 1 ]; then
+            go tool cover -func=cover.out
+            echo ""
+            echo "Quality Gate: checking test coverage is above threshold ..."
+            echo "Threshold             : $TESTCOVERAGE_THRESHOLD %"
+            totalCoverage=`go tool cover -func=cover.out | grep total | grep -Eo '[0-9]+\.[0-9]+'`
+            echo "Current test coverage : $totalCoverage %"
+            if (( $(echo "$totalCoverage $TESTCOVERAGE_THRESHOLD" | awk '{print ($1 >= $2)}') )); then
+                echo "OK"
+            else
+                echo "Current test coverage is below threshold. Please add more unit tests."
+                echo "Failed"
+                exit 1
+            fi
+          fi

--- a/Makefile
+++ b/Makefile
@@ -148,7 +148,12 @@ $(ENVTEST): $(LOCALBIN)
 
 .PHONY: test
 test: sdk-manifests vet envtest ## Run tests.
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test ./... -coverprofile cover.out
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test ./... -coverprofile cover.tmp.out -covermode count
+
+.PHONY: coverage
+coverage: test
+	cat cover.tmp.out | grep -v "_generated.*.go" > cover.out
+	go tool cover -func=cover.out
 
 ##@ Build
 release-build: bundle docker-build bundle-build bundle-push catalog-build ## Build operator docker, bundle, catalog images


### PR DESCRIPTION
We'll require at least 70% coverage for modified files.

an example of coverage passing the threshold -
```
github.com/RHEcosystemAppEng/dbaas-operator/controllers/dbaasinstance_controller.go:49:		Reconcile		86.7%
github.com/RHEcosystemAppEng/dbaas-operator/controllers/dbaasinstance_controller.go:111:	SetupWithManager	100.0%
github.com/RHEcosystemAppEng/dbaas-operator/controllers/dbaasinstance_controller.go:122:	mergeInstanceStatus	100.0%
github.com/RHEcosystemAppEng/dbaas-operator/controllers/dbaasinstance_controller.go:146:	Delete			80.0%
total:												(statements)		87.5%

Quality Gate: checking test coverage is above threshold ...
Threshold             : 70 %
Current test coverage : 87.5 %
OK
```

an example of it failing -
```
github.com/RHEcosystemAppEng/dbaas-operator/controllers/dbaasinstance_controller.go:49:							Reconcile		86.7%
github.com/RHEcosystemAppEng/dbaas-operator/controllers/dbaasinstance_controller.go:111:						SetupWithManager	100.0%
github.com/RHEcosystemAppEng/dbaas-operator/controllers/dbaasinstance_controller.go:122:						mergeInstanceStatus	100.0%
github.com/RHEcosystemAppEng/dbaas-operator/controllers/dbaasinstance_controller.go:146:						Delete			80.0%
github.com/RHEcosystemAppEng/dbaas-operator/controllers/reconcilers/quickstartinstallation/quickstart_installation_reconciler.go:47:	NewReconciler		0.0%
github.com/RHEcosystemAppEng/dbaas-operator/controllers/reconcilers/quickstartinstallation/quickstart_installation_reconciler.go:56:	Reconcile		0.0%
github.com/RHEcosystemAppEng/dbaas-operator/controllers/reconcilers/quickstartinstallation/quickstart_installation_reconciler.go:66:	createQuickStartCR	0.0%
github.com/RHEcosystemAppEng/dbaas-operator/controllers/reconcilers/quickstartinstallation/quickstart_installation_reconciler.go:90:	getQuickStartModel	0.0%
github.com/RHEcosystemAppEng/dbaas-operator/controllers/reconcilers/quickstartinstallation/quickstart_installation_reconciler.go:98:	Cleanup			0.0%
total:																	(statements)		56.8%

Quality Gate: checking test coverage is above threshold ...
Threshold             : 70 %
Current test coverage : 56.8 %
Current test coverage is below threshold. Please add more unit tests.
Failed
```

Signed-off-by: Tommy Hughes <tohughes@redhat.com>
