### PR TITLE
[DBAAS-974] fix envtest timeout waiting for process kube-apiserver to stop

### DIFF
--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -154,21 +154,15 @@ var _ = BeforeSuite(func() {
 
 	go func() {
 		defer GinkgoRecover()
-		err = k8sManager.Start(ctrl.SetupSignalHandler())
+		err = k8sManager.Start(ctx)
 		Expect(err).NotTo(HaveOccurred())
 	}()
 }, 60)
 
 var _ = AfterSuite(func() {
-	// https://github.com/kubernetes-sigs/controller-runtime/issues/1571
 	cancel()
-	By("tearing down the test environment,but I do nothing here.")
+	By("tearing down the test environment")
 	err := testEnv.Stop()
-	// Set 4 with random
-	if err != nil {
-		time.Sleep(4 * time.Second)
-	}
-	err = testEnv.Stop()
 	Expect(err).NotTo(HaveOccurred())
 	err = os.Unsetenv(InstallNamespaceEnvVar)
 	Expect(err).NotTo(HaveOccurred())

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -26,7 +26,6 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	"github.com/onsi/gomega/gexec"
 	operatorframework "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -48,6 +47,7 @@ import (
 
 var testEnv *envtest.Environment
 var ctx context.Context
+var cancel context.CancelFunc
 var dRec *DBaaSReconciler
 var iCtrl *spyctrl
 var cCtrl *spyctrl
@@ -94,7 +94,7 @@ var _ = BeforeSuite(func() {
 
 	//+kubebuilder:scaffold:scheme
 
-	ctx = context.Background()
+	ctx, cancel = context.WithCancel(context.Background())
 
 	err = os.Setenv(InstallNamespaceEnvVar, testNamespace)
 	Expect(err).NotTo(HaveOccurred())
@@ -155,13 +155,21 @@ var _ = BeforeSuite(func() {
 	go func() {
 		defer GinkgoRecover()
 		err = k8sManager.Start(ctrl.SetupSignalHandler())
-		Expect(err).ToNot(HaveOccurred(), "failed to run manager")
-		gexec.KillAndWait(4 * time.Second)
-
-		// Teardown the test environment once controller is fnished.
-		// Otherwise from Kubernetes 1.21+, teardon timeouts waiting on
-		// kube-apiserver to return
-		err := testEnv.Stop()
-		Expect(err).ToNot(HaveOccurred())
+		Expect(err).NotTo(HaveOccurred())
 	}()
 }, 60)
+
+var _ = AfterSuite(func() {
+	// https://github.com/kubernetes-sigs/controller-runtime/issues/1571
+	cancel()
+	By("tearing down the test environment,but I do nothing here.")
+	err := testEnv.Stop()
+	// Set 4 with random
+	if err != nil {
+		time.Sleep(4 * time.Second)
+	}
+	err = testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
+	err = os.Unsetenv(InstallNamespaceEnvVar)
+	Expect(err).NotTo(HaveOccurred())
+})


### PR DESCRIPTION
resolves this issue - 
https://github.com/kubernetes-sigs/controller-runtime/issues/1571

resolves hanging processes as well
```bash
  501 41503     1   0 10:41AM ttys000    1:13.34 /Users/<user>/workspace/dbaas-operator/bin/k8s/1.24.2-darwin-arm64/etcd --advertise-client-urls=http://127.0.0.1:50533 ...
  501 41507     1   0 10:41AM ttys000    6:52.17 /Users/<user>/workspace/dbaas-operator/bin/k8s/1.24.2-darwin-arm64/kube-apiserver --allow-privileged=true ...
```

Signed-off-by: Tommy Hughes <tohughes@redhat.com>
