### PR TITLE
[DBAAS-1044] DBaaS Connection Resource Metrics Addition

### DIFF
--- a/controllers/dbaasplatform_controller.go
+++ b/controllers/dbaasplatform_controller.go
@@ -36,6 +36,7 @@ import (
 
 	"github.com/go-logr/logr"
 
+	metrics "github.com/RHEcosystemAppEng/dbaas-operator/controllers/metrics"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -115,7 +116,7 @@ func (r *DBaaSPlatformReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	}
 
 	var finished = true
-	execution := PlatformInstallStart()
+	execution := metrics.PlatformInstallStart()
 	var platforms map[dbaasv1alpha1.PlatformsName]dbaasv1alpha1.PlatformConfig
 
 	consoleURL, err := util.GetOpenshiftConsoleURL(ctx, r.Client)
@@ -127,7 +128,7 @@ func (r *DBaaSPlatformReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	if err != nil {
 		logger.Error(err, "Error in getting of openshift platform Type")
 	}
-	SetOpenShiftInstallationInfoMetric(r.operatorNameVersion, consoleURL, string(platformType))
+	metrics.SetOpenShiftInstallationInfoMetric(r.operatorNameVersion, consoleURL, string(platformType))
 	if cr.DeletionTimestamp == nil {
 		platforms = reconcilers.InstallationPlatforms
 	}
@@ -143,11 +144,11 @@ func (r *DBaaSPlatformReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 
 			if cr.DeletionTimestamp == nil {
 				status, err = reconciler.Reconcile(ctx, cr)
-				SetPlatformStatusMetric(platform, status, platformConfig.CSV)
+				metrics.SetPlatformStatusMetric(platform, status, platformConfig.CSV)
 
 			} else {
 				status, err = reconciler.Cleanup(ctx, cr)
-				CleanPlatformStatusMetric(platform, status, platformConfig.CSV)
+				metrics.CleanPlatformStatusMetric(platform, status, platformConfig.CSV)
 			}
 
 			if err != nil {

--- a/controllers/metrics/dbaas_connection_metrics.go
+++ b/controllers/metrics/dbaas_connection_metrics.go
@@ -1,0 +1,87 @@
+package metrics
+
+import (
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	dbaasv1alpha1 "github.com/RHEcosystemAppEng/dbaas-operator/api/v1alpha1"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+const (
+	// Metric Names
+	MetricNameConnectionStatusReady = "dbaas_connection_status_ready"
+
+	// Resource label values
+	LabelResourceValueConnection = "dbaas_connection"
+
+	// Error Code Values
+	LabelErrorCdValueDevTopologyModified           = "dbaas_connection_dev_topology_modified"
+	LabelErrorCdValueErrReconcilingWithDevTopology = "dbaas_connection_err_reconciling_with_dev_topology"
+	LabelErrorCdValueInvalidNameSpace              = "dbaas_connection_err_invalid_name_space"
+	LabelErrorCdCannotReadInstance                 = "dbaas_connection_cannot_read_instance"
+	LabelErrorCdValueErrorDeletingConnection       = "error_deleting_connection"
+
+	// Label Names
+	MetricLabelConnectionName = "name"
+)
+
+// DBaaSConnectionStatusGauge defines a gauge for DBaaSConnectionStatus
+var DBaaSConnectionStatusGauge = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+	Name: MetricNameConnectionStatusReady,
+	Help: "The status of DBaaS connections, values ( ready=1, error / not ready=0 )",
+}, []string{MetricLabelProvider, MetricLabelAccountName, MetricLabelInstanceID, MetricLabelConnectionName, MetricLabelNameSpace, MetricLabelStatus, MetricLabelReason})
+
+// SetConnectionMetrics set the Metrics for a connection
+func SetConnectionMetrics(provider string, account string, connection dbaasv1alpha1.DBaaSConnection, execution Execution, event string, errCd string) {
+	log := ctrl.Log.WithName("Setting Connection Metrics")
+	log.Info("provider - " + provider + " account - " + account + " namespace - " + connection.Namespace + " event - " + event + " errCd - " + errCd)
+	setConnectionStatusMetrics(provider, account, connection)
+	setConnectionRequestDurationSeconds(provider, account, connection, execution, event)
+	UpdateErrorsTotal(provider, account, connection.Namespace, LabelResourceValueConnection, event, errCd)
+}
+
+// setConnectionStatusMetrics set the Metrics based on connection status
+func setConnectionStatusMetrics(provider string, account string, connection dbaasv1alpha1.DBaaSConnection) {
+	for _, cond := range connection.Status.Conditions {
+		if cond.Type == dbaasv1alpha1.DBaaSConnectionReadyType {
+			DBaaSConnectionStatusGauge.DeletePartialMatch(prometheus.Labels{MetricLabelName: connection.Name, MetricLabelNameSpace: connection.Namespace})
+			if cond.Reason == dbaasv1alpha1.Ready && cond.Status == metav1.ConditionTrue {
+				DBaaSConnectionStatusGauge.With(prometheus.Labels{MetricLabelProvider: provider, MetricLabelAccountName: account, MetricLabelInstanceID: connection.Spec.InstanceID, MetricLabelConnectionName: connection.GetName(), MetricLabelNameSpace: connection.Namespace, MetricLabelStatus: string(cond.Status), MetricLabelReason: cond.Reason}).Set(1)
+			} else {
+				DBaaSConnectionStatusGauge.With(prometheus.Labels{MetricLabelProvider: provider, MetricLabelAccountName: account, MetricLabelInstanceID: connection.Spec.InstanceID, MetricLabelConnectionName: connection.GetName(), MetricLabelNameSpace: connection.Namespace, MetricLabelStatus: string(cond.Status), MetricLabelReason: cond.Reason}).Set(0)
+			}
+			break
+		}
+	}
+}
+
+// setConnectionRequestDurationSeconds set the Metrics for connection request duration in seconds
+func setConnectionRequestDurationSeconds(provider string, account string, connection dbaasv1alpha1.DBaaSConnection, execution Execution, event string) {
+	log := ctrl.Log.WithName("Connection Request Duration for event: " + event)
+	switch event {
+	case LabelEventValueCreate:
+		for _, cond := range connection.Status.Conditions {
+			if cond.Type == dbaasv1alpha1.DBaaSConnectionProviderSyncType {
+				if cond.Status == metav1.ConditionTrue {
+					duration := time.Now().UTC().Sub(connection.CreationTimestamp.Time.UTC())
+					UpdateRequestsDurationHistogram(connection.Spec.InventoryRef.Name, connection.Name, connection.Namespace, LabelResourceValueConnection, event, duration.Seconds())
+					log.Info("Set the request duration for create event")
+				}
+			}
+		}
+	case LabelEventValueDelete:
+		deletionTimestamp := execution.begin.UTC()
+		if connection.DeletionTimestamp != nil {
+			deletionTimestamp = connection.DeletionTimestamp.UTC()
+		}
+
+		duration := time.Now().UTC().Sub(deletionTimestamp.UTC())
+		UpdateRequestsDurationHistogram(connection.Spec.InventoryRef.Name, connection.Name, connection.Namespace, LabelResourceValueConnection, event, duration.Seconds())
+		log.Info("Set the request duration for delete event")
+	}
+}

--- a/controllers/metrics/dbaas_inventory_metrics.go
+++ b/controllers/metrics/dbaas_inventory_metrics.go
@@ -1,0 +1,79 @@
+package metrics
+
+import (
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	dbaasv1alpha1 "github.com/RHEcosystemAppEng/dbaas-operator/api/v1alpha1"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+const (
+	// Metric Names
+	MetricNameInventoryStatusReady   = "dbaas_inventory_status_ready"
+	MetricNameDBaasInventoryDuration = "dbaas_inventory_request_duration_seconds"
+
+	// Resource label values
+	LabelResourceValueInventory = "dbaas_inventory"
+
+	// Error Code Values
+	LabelErrorCdValueErrorFetchingDBaaSInventoryResources = "error_fetching_dbaas_inventory_resources"
+	LabelErrorCdValueErrorUpdatingInventoryStatus         = "error_updating_inventory_status"
+	LabelErrorCdValueErrorDeletingInventory               = "error_deleting_inventory"
+	LabelErrorCdValueErrCheckingInventory                 = "dbaas_connection_err_checking_inventory"
+)
+
+// SetInventoryMetrics set the Metrics for inventory
+func SetInventoryMetrics(inventory dbaasv1alpha1.DBaaSInventory, execution Execution, event string, errCd string) {
+	setInventoryStatusMetrics(inventory)
+	setInventoryRequestDurationSeconds(inventory, event, execution)
+	UpdateErrorsTotal(inventory.Spec.ProviderRef.Name, inventory.Name, inventory.Namespace, LabelResourceValueInventory, event, errCd)
+}
+
+// setInventoryStatusMetrics set the Metrics for inventory status
+func setInventoryStatusMetrics(inventory dbaasv1alpha1.DBaaSInventory) {
+	for _, cond := range inventory.Status.Conditions {
+		if cond.Type == dbaasv1alpha1.DBaaSInventoryReadyType {
+			DBaaSInventoryStatusGauge.DeletePartialMatch(prometheus.Labels{MetricLabelProvider: inventory.Spec.ProviderRef.Name, MetricLabelName: inventory.Name, MetricLabelNameSpace: inventory.Namespace})
+			if cond.Reason == dbaasv1alpha1.Ready && cond.Status == metav1.ConditionTrue {
+				DBaaSInventoryStatusGauge.With(prometheus.Labels{MetricLabelProvider: inventory.Spec.ProviderRef.Name, MetricLabelName: inventory.Name, MetricLabelNameSpace: inventory.Namespace, MetricLabelStatus: string(cond.Status), MetricLabelReason: cond.Reason}).Set(1)
+			} else {
+				DBaaSInventoryStatusGauge.With(prometheus.Labels{MetricLabelProvider: inventory.Spec.ProviderRef.Name, MetricLabelName: inventory.Name, MetricLabelNameSpace: inventory.Namespace, MetricLabelStatus: string(cond.Status), MetricLabelReason: cond.Reason}).Set(0)
+			}
+			break
+		}
+	}
+}
+
+// setInventoryRequestDurationSeconds set the Metrics for inventory request duration in seconds
+func setInventoryRequestDurationSeconds(inventory dbaasv1alpha1.DBaaSInventory, event string, execution Execution) {
+	log := ctrl.Log.WithName("Inventory Request Duration for event: " + event)
+	switch event {
+
+	case LabelEventValueCreate:
+		for _, cond := range inventory.Status.Conditions {
+			if cond.Type == dbaasv1alpha1.DBaaSInventoryProviderSyncType {
+				if cond.Status == metav1.ConditionTrue {
+					duration := time.Now().UTC().Sub(inventory.CreationTimestamp.Time.UTC())
+					UpdateRequestsDurationHistogram(inventory.Spec.ProviderRef.Name, inventory.Name, inventory.Namespace, LabelResourceValueInventory, event, duration.Seconds())
+					log.Info("Set the request duration for create event")
+				}
+				break
+			}
+		}
+
+	case LabelEventValueDelete:
+		deletionTimestamp := execution.begin.UTC()
+		if inventory.DeletionTimestamp != nil {
+			deletionTimestamp = inventory.DeletionTimestamp.UTC()
+		}
+
+		duration := time.Now().UTC().Sub(deletionTimestamp.UTC())
+		UpdateRequestsDurationHistogram(inventory.Spec.ProviderRef.Name, inventory.Name, inventory.Namespace, LabelResourceValueInventory, event, duration.Seconds())
+		log.Info("Set the request duration for delete event")
+	}
+}

--- a/controllers/metrics/metrics.go
+++ b/controllers/metrics/metrics.go
@@ -1,0 +1,283 @@
+package metrics
+
+import (
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	dbaasv1alpha1 "github.com/RHEcosystemAppEng/dbaas-operator/api/v1alpha1"
+)
+
+const (
+	// Metrics names.
+	MetricNameDBaaSStackInstallationTotalDuration = "dbaas_stack_installation_total_duration_seconds"
+	MetricNameDBaaSPlatformInstallationStatus     = "dbaas_platform_installation_status"
+	MetricNameInstanceStatusReady                 = "dbaas_instance_status_ready"
+	MetricNameDBaasInstanceDuration               = "dbaas_instance_request_duration_seconds"
+	MetricNameInstancePhase                       = "dbaas_instance_phase"
+	MetricNameOperatorVersion                     = "dbaas_version_info"
+	MetricNameDBaaSRequestsDurationSeconds        = "dbaas_requests_duration_seconds"
+	MetricNameDBaaSRequestsErrorCount             = "dbaas_requests_error_count"
+
+	// Metrics labels.
+	MetricLabelName              = "name"
+	MetricLabelStatus            = "status"
+	MetricLabelVersion           = "version"
+	MetricLabelProvider          = "provider"
+	MetricLabelAccountName       = "account"
+	MetricLabelNameSpace         = "namespace"
+	MetricLabelInstanceID        = "instance_id"
+	MetricLabelReason            = "reason"
+	MetricLabelInstanceName      = "instance_name"
+	MetricLabelCreationTimestamp = "creation_timestamp"
+	MetricLabelConsoleULR        = "openshift_url"
+	MetricLabelPlatformName      = "cloud_platform_name"
+	MetricLabelResource          = "resource"
+	MetricLabelEvent             = "event"
+	MetricLabelErrorCd           = "error_cd"
+
+	// Event label values
+	LabelEventValueCreate = "create"
+	LabelEventValueDelete = "delete"
+
+	// Error Code label values
+	LabelErrorCdValueResourceNotFound     = "resource_not_found"
+	LabelErrorCdValueUnableToListPolicies = "unable_to_list_policies"
+
+	// installationTimeStart base time == 0
+	installationTimeStart = 0
+	// installationTimeWidth is the width of a bucket in the histogram, here it is 1m
+	installationTimeWidth = 60
+	// installationTimeBuckets is the number of buckets, here it 10 minutes worth of 1m buckets
+	installationTimeBuckets = 10
+)
+
+// DBaasPlatformInstallationGauge defines a gauge for DBaaSPlatformInstallationStatus
+var DBaasPlatformInstallationGauge = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+	Name: MetricNameDBaaSPlatformInstallationStatus,
+	Help: "The status of an installation of components and provider operators. values ( success=1, failed=0, in progress=2 ) ",
+}, []string{MetricLabelName, MetricLabelStatus, MetricLabelVersion})
+
+// DBaaSInventoryStatusGauge defines a gauge for DBaaSInventoryStatus
+var DBaaSInventoryStatusGauge = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+	Name: MetricNameInventoryStatusReady,
+	Help: "The status of DBaaS Provider Account, values ( ready=1, error / not ready=0 )",
+}, []string{MetricLabelProvider, MetricLabelName, MetricLabelNameSpace, MetricLabelStatus, MetricLabelReason})
+
+// DBaaSInstanceStatusGauge defines a gauge for DBaaSInstanceStatus
+var DBaaSInstanceStatusGauge = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+	Name: MetricNameInstanceStatusReady,
+	Help: "The status of DBaaS instance, values ( ready=1, error / not ready=0 )",
+}, []string{MetricLabelProvider, MetricLabelAccountName, MetricLabelInstanceName, MetricLabelNameSpace, MetricLabelStatus, MetricLabelReason, MetricLabelCreationTimestamp})
+
+// DBaaSInstancePhaseGauge defines a gauge for DBaaSInstancePhase
+var DBaaSInstancePhaseGauge = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+	Name: MetricNameInstancePhase,
+	Help: "Current status phase of the Instance currently managed by RHODA values ( Pending=-1, Creating=0, Ready=1, Unknown=2, Failed=3, Error=4, Deleting=5 ).",
+}, []string{MetricLabelProvider, MetricLabelAccountName, MetricLabelInstanceName, MetricLabelNameSpace, MetricLabelCreationTimestamp})
+
+// DBaasStackInstallationHistogram defines a histogram for DBaasStackInstallation
+var DBaasStackInstallationHistogram = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+	Name: MetricNameDBaaSStackInstallationTotalDuration,
+	Help: "Time in seconds installation of a DBaaS stack takes.",
+	Buckets: prometheus.LinearBuckets(
+		installationTimeStart,
+		installationTimeWidth,
+		installationTimeBuckets),
+}, []string{MetricLabelVersion, MetricLabelCreationTimestamp})
+
+// DBaasInventoryRequestDurationSeconds defines a histogram for DBaasInventoryRequestDuration in seconds
+var DBaasInventoryRequestDurationSeconds = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+	Name: MetricNameDBaasInventoryDuration,
+	Help: "Request/Response duration of provider account of upstream calls to provider operator/service endpoints",
+	Buckets: prometheus.LinearBuckets(installationTimeStart,
+		installationTimeWidth,
+		installationTimeBuckets),
+}, []string{MetricLabelProvider, MetricLabelName, MetricLabelNameSpace, MetricLabelCreationTimestamp})
+
+// DBaasOperatorVersionInfo defines a gauge for DBaaS Operator version
+var DBaasOperatorVersionInfo = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+	Name: MetricNameOperatorVersion,
+	Help: "The current version of DBaaS Operator installed in the cluster",
+}, []string{MetricLabelVersion, MetricLabelConsoleULR, MetricLabelPlatformName})
+
+// DBaasInstanceRequestDurationSeconds defines a histogram for DBaasInstanceRequestDuration
+var DBaasInstanceRequestDurationSeconds = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+	Name: MetricNameDBaasInstanceDuration,
+	Help: "Request/Response duration of instance of upstream calls to provider operator/service endpoints",
+}, []string{MetricLabelProvider, MetricLabelAccountName, MetricLabelInstanceName, MetricLabelNameSpace, MetricLabelCreationTimestamp})
+
+// DBaaSRequestsDurationHistogram DBaaS Requests Duration Histogram for all DBaaS Resources
+var DBaaSRequestsDurationHistogram = prometheus.NewHistogramVec(
+	prometheus.HistogramOpts{
+		Name: MetricNameDBaaSRequestsDurationSeconds,
+		Help: "Request durations histogram for given resource(e.g. inventory) and for a given event(e.g. create or delete)",
+	},
+	[]string{MetricLabelProvider, MetricLabelAccountName, MetricLabelNameSpace, MetricLabelResource, MetricLabelEvent})
+
+// DBaaSRequestsErrorsCounter Total errors encountered counter
+var DBaaSRequestsErrorsCounter = prometheus.NewCounterVec(
+	prometheus.CounterOpts{
+		Name: MetricNameDBaaSRequestsErrorCount,
+		Help: "Total requests for a given resource(e.g. DBaaS Inventory), for a given event(e.g. create or delete), with a given error code (e.g. resource exists, resource not there)",
+	},
+	[]string{MetricLabelProvider, MetricLabelAccountName, MetricLabelNameSpace, MetricLabelResource, MetricLabelEvent, MetricLabelErrorCd})
+
+// Execution tracks state for an API execution for emitting Metrics
+type Execution struct {
+	begin time.Time
+}
+
+// PlatformInstallStart creates an Execution instance and starts the timer
+func PlatformInstallStart() Execution {
+	return Execution{
+		begin: time.Now().UTC(),
+	}
+}
+
+// PlatformStackInstallationMetric is used to log duration and success/failure
+func (e *Execution) PlatformStackInstallationMetric(platform *dbaasv1alpha1.DBaaSPlatform, version string) {
+	duration := time.Since(e.begin)
+	for _, cond := range platform.Status.Conditions {
+		if cond.Type == dbaasv1alpha1.DBaaSPlatformReadyType {
+			lastTransitionTime := cond.LastTransitionTime
+			duration = lastTransitionTime.Sub(platform.CreationTimestamp.Time)
+			DBaasStackInstallationHistogram.With(prometheus.Labels{MetricLabelVersion: version, MetricLabelCreationTimestamp: platform.CreationTimestamp.String()}).Observe(duration.Seconds())
+		} else {
+			DBaasStackInstallationHistogram.With(prometheus.Labels{MetricLabelVersion: version, MetricLabelCreationTimestamp: platform.CreationTimestamp.String()}).Observe(duration.Seconds())
+		}
+	}
+}
+
+// SetPlatformStatusMetric exposes dbaas_platform_status Metric for each platform
+func SetPlatformStatusMetric(platformName dbaasv1alpha1.PlatformsName, status dbaasv1alpha1.PlatformsInstlnStatus, version string) {
+	if len(platformName) > 0 {
+		switch status {
+
+		case dbaasv1alpha1.ResultFailed:
+			DBaasPlatformInstallationGauge.With(prometheus.Labels{MetricLabelName: string(platformName), MetricLabelStatus: string(status), MetricLabelVersion: version}).Set(float64(0))
+			DBaasPlatformInstallationGauge.Delete(prometheus.Labels{MetricLabelName: string(platformName), MetricLabelStatus: string(dbaasv1alpha1.ResultSuccess), MetricLabelVersion: version})
+			DBaasPlatformInstallationGauge.Delete(prometheus.Labels{MetricLabelName: string(platformName), MetricLabelStatus: string(dbaasv1alpha1.ResultInProgress), MetricLabelVersion: version})
+		case dbaasv1alpha1.ResultSuccess:
+			DBaasPlatformInstallationGauge.Delete(prometheus.Labels{MetricLabelName: string(platformName), MetricLabelStatus: string(dbaasv1alpha1.ResultInProgress), MetricLabelVersion: version})
+			DBaasPlatformInstallationGauge.Delete(prometheus.Labels{MetricLabelName: string(platformName), MetricLabelStatus: string(dbaasv1alpha1.ResultFailed), MetricLabelVersion: version})
+			DBaasPlatformInstallationGauge.With(prometheus.Labels{MetricLabelName: string(platformName), MetricLabelStatus: string(status), MetricLabelVersion: version}).Set(float64(1))
+		case dbaasv1alpha1.ResultInProgress:
+			DBaasPlatformInstallationGauge.With(prometheus.Labels{MetricLabelName: string(platformName), MetricLabelStatus: string(status), MetricLabelVersion: version}).Set(float64(2))
+			DBaasPlatformInstallationGauge.Delete(prometheus.Labels{MetricLabelName: string(platformName), MetricLabelStatus: string(dbaasv1alpha1.ResultSuccess), MetricLabelVersion: version})
+			DBaasPlatformInstallationGauge.Delete(prometheus.Labels{MetricLabelName: string(platformName), MetricLabelStatus: string(dbaasv1alpha1.ResultFailed), MetricLabelVersion: version})
+
+		}
+	}
+}
+
+// CleanPlatformStatusMetric delete the dbaas_platform_status Metric for each platform
+func CleanPlatformStatusMetric(platformName dbaasv1alpha1.PlatformsName, status dbaasv1alpha1.PlatformsInstlnStatus, version string) {
+	if len(platformName) > 0 && status == dbaasv1alpha1.ResultSuccess {
+		DBaasPlatformInstallationGauge.Delete(prometheus.Labels{MetricLabelName: string(platformName), MetricLabelStatus: string(dbaasv1alpha1.ResultSuccess), MetricLabelVersion: version})
+	}
+}
+
+// SetOpenShiftInstallationInfoMetric set the Metrics for openshift info
+func SetOpenShiftInstallationInfoMetric(operatorVersion string, consoleURL string, platformType string) {
+	DBaasOperatorVersionInfo.With(prometheus.Labels{MetricLabelVersion: operatorVersion, MetricLabelConsoleULR: consoleURL, MetricLabelPlatformName: platformType}).Set(1)
+}
+
+// SetInstanceMetrics set the Metrics for an instance
+func SetInstanceMetrics(provider string, account string, instance dbaasv1alpha1.DBaaSInstance, execution Execution) {
+	setInstanceStatusMetrics(provider, account, instance)
+	setInstancePhaseMetrics(provider, account, instance)
+	setInstanceRequestDurationSeconds(provider, account, instance, execution)
+
+}
+
+// setInstanceStatusMetrics set the Metrics based on instance status
+func setInstanceStatusMetrics(provider string, account string, instance dbaasv1alpha1.DBaaSInstance) {
+	for _, cond := range instance.Status.Conditions {
+		if cond.Type == dbaasv1alpha1.DBaaSInstanceReadyType {
+			DBaaSInstanceStatusGauge.DeletePartialMatch(prometheus.Labels{MetricLabelInstanceName: instance.GetName(), MetricLabelNameSpace: instance.Namespace})
+			if cond.Reason == dbaasv1alpha1.Ready && cond.Status == metav1.ConditionTrue {
+				DBaaSInstanceStatusGauge.With(prometheus.Labels{MetricLabelProvider: provider, MetricLabelAccountName: account, MetricLabelInstanceName: instance.GetName(), MetricLabelNameSpace: instance.Namespace, MetricLabelStatus: string(cond.Status), MetricLabelReason: cond.Reason, MetricLabelCreationTimestamp: instance.CreationTimestamp.String()}).Set(1)
+			} else {
+				DBaaSInstanceStatusGauge.With(prometheus.Labels{MetricLabelProvider: provider, MetricLabelAccountName: account, MetricLabelInstanceName: instance.GetName(), MetricLabelNameSpace: instance.Namespace, MetricLabelStatus: string(cond.Status), MetricLabelReason: cond.Reason, MetricLabelCreationTimestamp: instance.CreationTimestamp.String()}).Set(0)
+			}
+			break
+		}
+	}
+}
+
+// setInstanceRequestDurationSeconds set the Metrics for instance request duration in seconds
+func setInstanceRequestDurationSeconds(provider string, account string, instance dbaasv1alpha1.DBaaSInstance, execution Execution) {
+	httpDuration := time.Since(execution.begin)
+	for _, cond := range instance.Status.Conditions {
+		if cond.Type == dbaasv1alpha1.DBaaSInstanceProviderSyncType {
+			if cond.Status == metav1.ConditionTrue {
+				lastTransitionTime := cond.LastTransitionTime
+				httpDuration = lastTransitionTime.Sub(instance.CreationTimestamp.Time)
+				DBaasInstanceRequestDurationSeconds.With(prometheus.Labels{MetricLabelProvider: provider, MetricLabelAccountName: account, MetricLabelInstanceName: instance.GetName(), MetricLabelNameSpace: instance.GetNamespace(), MetricLabelCreationTimestamp: instance.CreationTimestamp.String()}).Observe(httpDuration.Seconds())
+			} else {
+				DBaasInstanceRequestDurationSeconds.With(prometheus.Labels{MetricLabelProvider: provider, MetricLabelAccountName: account, MetricLabelInstanceName: instance.GetName(), MetricLabelNameSpace: instance.GetNamespace(), MetricLabelCreationTimestamp: instance.CreationTimestamp.String()}).Observe(httpDuration.Seconds())
+			}
+			break
+		}
+	}
+}
+
+// setInstancePhaseMetrics set the Metrics for instance phase
+func setInstancePhaseMetrics(provider string, account string, instance dbaasv1alpha1.DBaaSInstance) {
+	var phase float64
+
+	switch instance.Status.Phase {
+	case dbaasv1alpha1.InstancePhasePending:
+		phase = -1
+	case dbaasv1alpha1.InstancePhaseCreating:
+		phase = 0
+	case dbaasv1alpha1.InstancePhaseReady:
+		phase = 1
+	case dbaasv1alpha1.InstancePhaseUnknown:
+		phase = 2
+	case dbaasv1alpha1.InstancePhaseFailed:
+		phase = 3
+	case dbaasv1alpha1.InstancePhaseError:
+		phase = 4
+	case dbaasv1alpha1.InstancePhaseDeleting:
+		phase = 5
+	case dbaasv1alpha1.InstancePhaseDeleted:
+		phase = 6
+	}
+
+	DBaaSInstancePhaseGauge.With(prometheus.Labels{
+		MetricLabelProvider:          provider,
+		MetricLabelAccountName:       account,
+		MetricLabelInstanceName:      instance.Name,
+		MetricLabelNameSpace:         instance.Namespace,
+		MetricLabelCreationTimestamp: instance.CreationTimestamp.String(),
+	}).Set(phase)
+}
+
+// CleanInstanceMetrics delete instance Metrics based on the condition type
+func CleanInstanceMetrics(instance *dbaasv1alpha1.DBaaSInstance) {
+	for _, cond := range instance.Status.Conditions {
+		switch cond.Type {
+		case dbaasv1alpha1.DBaaSInstanceReadyType:
+			DBaaSInstanceStatusGauge.DeletePartialMatch(prometheus.Labels{MetricLabelInstanceName: instance.GetName(), MetricLabelNameSpace: instance.Namespace})
+			DBaaSInstancePhaseGauge.DeletePartialMatch(prometheus.Labels{MetricLabelInstanceName: instance.Name, MetricLabelNameSpace: instance.Namespace})
+		case dbaasv1alpha1.DBaaSInstanceProviderSyncType:
+			DBaasInstanceRequestDurationSeconds.DeletePartialMatch(prometheus.Labels{MetricLabelInstanceName: instance.GetName(), MetricLabelNameSpace: instance.GetNamespace()})
+		}
+	}
+}
+
+// UpdateRequestsDurationHistogram Utility function to update request duration histogram
+func UpdateRequestsDurationHistogram(provider string, account string, namespace string, resource string, event string, duration float64) {
+	DBaaSRequestsDurationHistogram.WithLabelValues(provider, account, namespace, resource, event).Observe(duration)
+}
+
+// UpdateErrorsTotal Utility function to update errors total
+func UpdateErrorsTotal(provider string, account string, namespace string, resource string, event string, errCd string) {
+	if len(errCd) > 0 {
+		DBaaSRequestsErrorsCounter.WithLabelValues(provider, account, namespace, resource, event, errCd).Add(1)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -50,6 +50,7 @@ import (
 
 	"github.com/RHEcosystemAppEng/dbaas-operator/api/v1alpha1"
 	"github.com/RHEcosystemAppEng/dbaas-operator/controllers"
+	metrics "github.com/RHEcosystemAppEng/dbaas-operator/controllers/metrics"
 	//+kubebuilder:scaffold:imports
 )
 
@@ -61,16 +62,15 @@ var (
 func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 	// Register custom metrics with the global prometheus registry
-	customMetrics.Registry.MustRegister(controllers.DBaasStackInstallationHistogram)
-	customMetrics.Registry.MustRegister(controllers.DBaasPlatformInstallationGauge)
-	customMetrics.Registry.MustRegister(controllers.DBaaSConnectionStatusGauge)
-	customMetrics.Registry.MustRegister(controllers.DBaaSInstanceStatusGauge)
-	customMetrics.Registry.MustRegister(controllers.DBaaSInstancePhaseGauge)
-	customMetrics.Registry.MustRegister(controllers.DBaasConnectionRequestDurationSeconds)
-	customMetrics.Registry.MustRegister(controllers.DBaasInstanceRequestDurationSeconds)
-	customMetrics.Registry.MustRegister(controllers.DBaasOperatorVersionInfo)
-	customMetrics.Registry.MustRegister(controllers.DBaaSRequestsDurationHistogram)
-	customMetrics.Registry.MustRegister(controllers.DBaaSRequestsErrorsCounter)
+	customMetrics.Registry.MustRegister(metrics.DBaasStackInstallationHistogram)
+	customMetrics.Registry.MustRegister(metrics.DBaasPlatformInstallationGauge)
+	customMetrics.Registry.MustRegister(metrics.DBaaSConnectionStatusGauge)
+	customMetrics.Registry.MustRegister(metrics.DBaaSInstanceStatusGauge)
+	customMetrics.Registry.MustRegister(metrics.DBaaSInstancePhaseGauge)
+	customMetrics.Registry.MustRegister(metrics.DBaasInstanceRequestDurationSeconds)
+	customMetrics.Registry.MustRegister(metrics.DBaasOperatorVersionInfo)
+	customMetrics.Registry.MustRegister(metrics.DBaaSRequestsDurationHistogram)
+	customMetrics.Registry.MustRegister(metrics.DBaaSRequestsErrorsCounter)
 
 	utilruntime.Must(v1alpha1.AddToScheme(scheme))
 	utilruntime.Must(operatorframework.AddToScheme(scheme))


### PR DESCRIPTION
## Description
DBaaSConnection metrics based on the design proposal at this [link](https://docs.google.com/presentation/d/1R9jdTdBwDp70Xlr9r_83nsbG7JUqA8I0DsnKE_N3hsk/edit?usp=sharing)

Prometheus Output Console
<img width="1213" alt="image" src="https://user-images.githubusercontent.com/87712456/202539384-5863b1b5-3910-4ba9-81c1-3bc3a6b316ae.png">

## Verification Steps on OpenShift Local
* Please check screenshot of the Prometheus output [here](https://docs.google.com/document/d/1EA4U7mFSQHsq8xS-cfvPuQ7BxdUh9ziCE0OZZKF-H_0/edit?usp=sharing)
* On fresh Openshift Local instance, in a terminal window login with admin credentials and deploy DBaaS Operator 

```shell
oc apply -f config/samples/installation-for-non-OSD-OCP-environments.yaml
```
* Once the DBaaS Operator is fully installed, expose the Prometheus service and navigate to the prometheus service in the browser

```shell
oc project openshift-dbaas-operator
oc expose svc/prometheus-operated
oc get route
```

* Deploy Mongo Quick Start sample
```shell
oc create ns dbaas-rhkp
oc project dbaas-rhkp
oc apply -f mongo-quickstart/deployment.yaml 
```

* Follow usual process to add provider such as MongoDB Atlas with Org Id, Public Key and Secret. ( Namespace: openshift-dbaas-operator, Database Services -> Database Access )
* Create the Database Instance from Data Services -> Data Access -> Configuration -> Create Database Instance. Select appropriate Provider Account, Instance & Project Name and create the instance.
* Switch to Developer Perspective -> + Add -> Cloud Hosted Database -> MongoDB Atlas Cloud Database Service -> Add to Topology, Select Instance and hit Add to Topology
* Check the prometheus console with dbaas_requests_duration_seconds_bucket, dbaas_requests_duration_seconds_count, dbaas_requests_duration_seconds_sum metrics with resource: dbaas_connection and event: create.
* You may see metric dbaas_requests_error_count in case if there were errors, just in case.
Developer Perspective -> 3 dots of Connection -> Delete DBaaSConnection, check the prometheuy metrics again with resource: dbaas_connection and event: delete.
* Delete the installed operator with
```shell
oc delete -f config/samples/installation-for-non-OSD-OCP-environments.yaml
```

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Enhancements to an existing feature

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA or in issue number have been completed
- [ ] Documentation added for the feature
- [ ] all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer