### PR TITLE
[DBAAS-1092]-DBaaSPlatform Metrics Initial Implementation

### DIFF
--- a/controllers/metrics/dbaas_connection_metrics.go
+++ b/controllers/metrics/dbaas_connection_metrics.go
@@ -47,13 +47,17 @@ func SetConnectionMetrics(provider string, account string, connection dbaasv1alp
 
 // setConnectionStatusMetrics set the Metrics based on connection status
 func setConnectionStatusMetrics(provider string, account string, connection dbaasv1alpha1.DBaaSConnection) {
+	log := ctrl.Log.WithName("Setting DBaaSConnectionStatusGauge: ")
+	log.Info("Started")
 	for _, cond := range connection.Status.Conditions {
 		if cond.Type == dbaasv1alpha1.DBaaSConnectionReadyType {
 			DBaaSConnectionStatusGauge.DeletePartialMatch(prometheus.Labels{MetricLabelName: connection.Name, MetricLabelNameSpace: connection.Namespace})
 			if cond.Reason == dbaasv1alpha1.Ready && cond.Status == metav1.ConditionTrue {
 				DBaaSConnectionStatusGauge.With(prometheus.Labels{MetricLabelProvider: provider, MetricLabelAccountName: account, MetricLabelInstanceID: connection.Spec.InstanceID, MetricLabelConnectionName: connection.GetName(), MetricLabelNameSpace: connection.Namespace, MetricLabelStatus: string(cond.Status), MetricLabelReason: cond.Reason}).Set(1)
+				log.Info("Set to 1")
 			} else {
 				DBaaSConnectionStatusGauge.With(prometheus.Labels{MetricLabelProvider: provider, MetricLabelAccountName: account, MetricLabelInstanceID: connection.Spec.InstanceID, MetricLabelConnectionName: connection.GetName(), MetricLabelNameSpace: connection.Namespace, MetricLabelStatus: string(cond.Status), MetricLabelReason: cond.Reason}).Set(0)
+				log.Info("Set to 1")
 			}
 			break
 		}

--- a/controllers/metrics/dbaas_instance_metrics.go
+++ b/controllers/metrics/dbaas_instance_metrics.go
@@ -14,9 +14,8 @@ import (
 
 const (
 	// Metric Names
-	metricNameInstanceStatusReady   = "dbaas_instance_status_ready"
-	metricNameDBaasInstanceDuration = "dbaas_instance_request_duration_seconds"
-	metricNameInstancePhase         = "dbaas_instance_phase"
+	metricNameInstanceStatusReady = "dbaas_instance_status_ready"
+	metricNameInstancePhase       = "dbaas_instance_phase"
 
 	metricLabelInstanceID   = "instance_id"
 	metricLabelInstanceName = "instance_name"
@@ -44,13 +43,17 @@ var DBaaSInstancePhaseGauge = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 
 // setInstanceStatusMetrics set the metrics based on instance status
 func setInstanceStatusMetrics(provider string, account string, instance dbaasv1alpha1.DBaaSInstance) {
+	log := ctrl.Log.WithName("Setting DBaaSInstanceStatusGauge: ")
+	log.Info("Started")
 	for _, cond := range instance.Status.Conditions {
 		if cond.Type == dbaasv1alpha1.DBaaSInstanceReadyType {
 			DBaaSInstanceStatusGauge.DeletePartialMatch(prometheus.Labels{metricLabelInstanceName: instance.GetName(), MetricLabelNameSpace: instance.Namespace})
 			if cond.Reason == dbaasv1alpha1.Ready && cond.Status == metav1.ConditionTrue {
 				DBaaSInstanceStatusGauge.With(prometheus.Labels{MetricLabelProvider: provider, MetricLabelAccountName: account, metricLabelInstanceName: instance.GetName(), MetricLabelNameSpace: instance.Namespace, MetricLabelStatus: string(cond.Status), MetricLabelReason: cond.Reason}).Set(1)
+				log.Info("Set to 1")
 			} else {
 				DBaaSInstanceStatusGauge.With(prometheus.Labels{MetricLabelProvider: provider, MetricLabelAccountName: account, metricLabelInstanceName: instance.GetName(), MetricLabelNameSpace: instance.Namespace, MetricLabelStatus: string(cond.Status), MetricLabelReason: cond.Reason}).Set(0)
+				log.Info("Set to 0")
 			}
 			break
 		}
@@ -85,6 +88,8 @@ func setInstanceRequestDurationSeconds(provider string, account string, instance
 
 // setInstancePhaseMetrics set the metrics for instance phase
 func setInstancePhaseMetrics(provider string, account string, instance dbaasv1alpha1.DBaaSInstance) {
+	log := ctrl.Log.WithName("Setting DBaaSInstancePhaseGauge: ")
+	log.Info("Started")
 	var phase float64
 
 	switch instance.Status.Phase {
@@ -112,6 +117,8 @@ func setInstancePhaseMetrics(provider string, account string, instance dbaasv1al
 		metricLabelInstanceName: instance.Name,
 		MetricLabelNameSpace:    instance.Namespace,
 	}).Set(phase)
+
+	log.Info("Set to ", "phase", phase)
 }
 
 // SetInstanceMetrics set the metrics for an instance

--- a/controllers/metrics/dbaas_inventory_metrics.go
+++ b/controllers/metrics/dbaas_inventory_metrics.go
@@ -14,8 +14,7 @@ import (
 
 const (
 	// Metric Names
-	MetricNameInventoryStatusReady   = "dbaas_inventory_status_ready"
-	MetricNameDBaasInventoryDuration = "dbaas_inventory_request_duration_seconds"
+	MetricNameInventoryStatusReady = "dbaas_inventory_status_ready"
 
 	// Resource label values
 	LabelResourceValueInventory = "dbaas_inventory"
@@ -42,13 +41,17 @@ func SetInventoryMetrics(inventory dbaasv1alpha1.DBaaSInventory, execution Execu
 
 // setInventoryStatusMetrics set the Metrics for inventory status
 func setInventoryStatusMetrics(inventory dbaasv1alpha1.DBaaSInventory) {
+	log := ctrl.Log.WithName("Setting DBaaSInventoryStatusGauge: ")
+	log.Info("Started")
 	for _, cond := range inventory.Status.Conditions {
 		if cond.Type == dbaasv1alpha1.DBaaSInventoryReadyType {
 			DBaaSInventoryStatusGauge.DeletePartialMatch(prometheus.Labels{MetricLabelProvider: inventory.Spec.ProviderRef.Name, MetricLabelName: inventory.Name, MetricLabelNameSpace: inventory.Namespace})
 			if cond.Reason == dbaasv1alpha1.Ready && cond.Status == metav1.ConditionTrue {
 				DBaaSInventoryStatusGauge.With(prometheus.Labels{MetricLabelProvider: inventory.Spec.ProviderRef.Name, MetricLabelName: inventory.Name, MetricLabelNameSpace: inventory.Namespace, MetricLabelStatus: string(cond.Status), MetricLabelReason: cond.Reason}).Set(1)
+				log.Info("Set to 1")
 			} else {
 				DBaaSInventoryStatusGauge.With(prometheus.Labels{MetricLabelProvider: inventory.Spec.ProviderRef.Name, MetricLabelName: inventory.Name, MetricLabelNameSpace: inventory.Namespace, MetricLabelStatus: string(cond.Status), MetricLabelReason: cond.Reason}).Set(0)
+				log.Info("Set to 0")
 			}
 			break
 		}


### PR DESCRIPTION
## Description
DBaaSPlatform Metrics Initial Implementation

<img width="1254" alt="image" src="https://user-images.githubusercontent.com/87712456/206468627-6f6be6bc-e953-41f0-af1b-2fcf43974619.png">

## Verification Steps
Add the steps required to check this change. Following an example.

1. Install the DBaaS Operator on a fresh OpenShift cluster.
2. After successful installation expose the Prometheus service
`
oc project openshift-dbaas-operator;
oc expose svc/prometheus-operated;
oc get route;
`
3. Navigate to Prometheus Service Route in the browser, select a metric such as "dbaas_requests_duration_seconds_sum" and see the resource="dbaas_platform" appear.

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] New feature (non-breaking change which adds functionality)

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA or in issue number have been completed
- [ ] Unit tests added that prove the fix is effective or the feature works 
- [ ] Documentation added for the feature
- [ ] all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer