### PR TITLE
[DBAAS-1096] Rework metric pattern using DBaaSPolicy

### DIFF
--- a/controllers/metrics/dbaas_policy_metrics.go
+++ b/controllers/metrics/dbaas_policy_metrics.go
@@ -1,0 +1,48 @@
+package metrics
+
+import (
+	"time"
+
+	dbaasv1alpha1 "github.com/RHEcosystemAppEng/dbaas-operator/api/v1alpha1"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+const (
+	// Resource label values
+	LabelResourceValuePolicy = "dbaas_policy"
+
+	// Error Code label values
+	LabelErrorCdValueErrorFetchingDBaaSPolicyResources = "error_fetching_dbaas_policy_resource"
+	LabelErrorCdValueErrorResourceQuotaModified        = "error_resource_quota_modified"
+	LabelErrorCdValueErrUpdatingResourceQuota          = "error_updating_resource_quota"
+	LabelErrorCdValueErrorDeletingPolicy               = "error_deleting_dbaas_policy"
+)
+
+// SetPolicyMetrics set the Metrics for policy
+func SetPolicyMetrics(policy dbaasv1alpha1.DBaaSPolicy, execution Execution, event string, errCd string) {
+	setPolicyRequestDurationSeconds(policy, event, execution)
+	UpdateErrorsTotal(policy.Name, policy.Name, policy.Namespace, LabelResourceValuePolicy, event, errCd)
+}
+
+// setPolicyRequestDurationSeconds set the Metrics for policy request duration in seconds
+func setPolicyRequestDurationSeconds(policy dbaasv1alpha1.DBaaSPolicy, event string, execution Execution) {
+	log := ctrl.Log.WithName("Policy Request Duration for event: " + event)
+	switch event {
+
+	case LabelEventValueCreate:
+		duration := time.Now().UTC().Sub(policy.CreationTimestamp.Time.UTC())
+		UpdateRequestsDurationHistogram(policy.Name, policy.Name, policy.Namespace, LabelResourceValuePolicy, event, duration.Seconds())
+		log.Info("Set the request duration for create event")
+
+	case LabelEventValueDelete:
+		deletionTimestamp := execution.begin.UTC()
+		if policy.DeletionTimestamp != nil {
+			deletionTimestamp = policy.DeletionTimestamp.UTC()
+		}
+
+		duration := time.Now().UTC().Sub(deletionTimestamp.UTC())
+		UpdateRequestsDurationHistogram(policy.Name, policy.Name, policy.Namespace, LabelResourceValuePolicy, event, duration.Seconds())
+		log.Info("Set the request duration for delete event")
+	}
+}


### PR DESCRIPTION
## Description
Initial implementation of DBaaSPolicy Metrics.

<img width="1274" alt="image" src="https://user-images.githubusercontent.com/87712456/207674580-60b703b6-4321-4c30-94d9-7ba50e292f90.png">

## Verification Steps
Install the DBaaS Operator on a fresh OpenShift cluster.
After successful installation expose the Prometheus service
`
oc project openshift-dbaas-operator &&
oc expose svc/prometheus-operated &&
oc get route 
`
Navigate to Prometheus Service Route in the browser, select a metric such as "dbaas_requests_duration_seconds_sum" and see the resource="dbaas_policy" appear.

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] New feature (non-breaking change which adds functionality)

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA or in issue number have been completed
- [ ] Unit tests added that prove the fix is effective or the feature works 
- [ ] Documentation added for the feature
- [ ] all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer