### PR TITLE
[DBAAS-1092] Remove logging from setConnectionStatusMetrics

### DIFF
--- a/controllers/metrics/dbaas_connection_metrics.go
+++ b/controllers/metrics/dbaas_connection_metrics.go
@@ -47,17 +47,13 @@ func SetConnectionMetrics(provider string, account string, connection dbaasv1alp
 
 // setConnectionStatusMetrics set the Metrics based on connection status
 func setConnectionStatusMetrics(provider string, account string, connection dbaasv1alpha1.DBaaSConnection) {
-	log := ctrl.Log.WithName("Setting DBaaSConnectionStatusGauge: ")
-	log.Info("Started")
 	for _, cond := range connection.Status.Conditions {
 		if cond.Type == dbaasv1alpha1.DBaaSConnectionReadyType {
 			DBaaSConnectionStatusGauge.DeletePartialMatch(prometheus.Labels{MetricLabelName: connection.Name, MetricLabelNameSpace: connection.Namespace})
 			if cond.Reason == dbaasv1alpha1.Ready && cond.Status == metav1.ConditionTrue {
 				DBaaSConnectionStatusGauge.With(prometheus.Labels{MetricLabelProvider: provider, MetricLabelAccountName: account, MetricLabelInstanceID: connection.Spec.InstanceID, MetricLabelConnectionName: connection.GetName(), MetricLabelNameSpace: connection.Namespace, MetricLabelStatus: string(cond.Status), MetricLabelReason: cond.Reason}).Set(1)
-				log.Info("Set to 1")
 			} else {
 				DBaaSConnectionStatusGauge.With(prometheus.Labels{MetricLabelProvider: provider, MetricLabelAccountName: account, MetricLabelInstanceID: connection.Spec.InstanceID, MetricLabelConnectionName: connection.GetName(), MetricLabelNameSpace: connection.Namespace, MetricLabelStatus: string(cond.Status), MetricLabelReason: cond.Reason}).Set(0)
-				log.Info("Set to 1")
 			}
 			break
 		}

--- a/controllers/metrics/dbaas_instance_metrics.go
+++ b/controllers/metrics/dbaas_instance_metrics.go
@@ -43,17 +43,13 @@ var DBaaSInstancePhaseGauge = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 
 // setInstanceStatusMetrics set the metrics based on instance status
 func setInstanceStatusMetrics(provider string, account string, instance dbaasv1alpha1.DBaaSInstance) {
-	log := ctrl.Log.WithName("Setting DBaaSInstanceStatusGauge: ")
-	log.Info("Started")
 	for _, cond := range instance.Status.Conditions {
 		if cond.Type == dbaasv1alpha1.DBaaSInstanceReadyType {
 			DBaaSInstanceStatusGauge.DeletePartialMatch(prometheus.Labels{metricLabelInstanceName: instance.GetName(), MetricLabelNameSpace: instance.Namespace})
 			if cond.Reason == dbaasv1alpha1.Ready && cond.Status == metav1.ConditionTrue {
 				DBaaSInstanceStatusGauge.With(prometheus.Labels{MetricLabelProvider: provider, MetricLabelAccountName: account, metricLabelInstanceName: instance.GetName(), MetricLabelNameSpace: instance.Namespace, MetricLabelStatus: string(cond.Status), MetricLabelReason: cond.Reason}).Set(1)
-				log.Info("Set to 1")
 			} else {
 				DBaaSInstanceStatusGauge.With(prometheus.Labels{MetricLabelProvider: provider, MetricLabelAccountName: account, metricLabelInstanceName: instance.GetName(), MetricLabelNameSpace: instance.Namespace, MetricLabelStatus: string(cond.Status), MetricLabelReason: cond.Reason}).Set(0)
-				log.Info("Set to 0")
 			}
 			break
 		}
@@ -88,8 +84,6 @@ func setInstanceRequestDurationSeconds(provider string, account string, instance
 
 // setInstancePhaseMetrics set the metrics for instance phase
 func setInstancePhaseMetrics(provider string, account string, instance dbaasv1alpha1.DBaaSInstance) {
-	log := ctrl.Log.WithName("Setting DBaaSInstancePhaseGauge: ")
-	log.Info("Started")
 	var phase float64
 
 	switch instance.Status.Phase {
@@ -117,8 +111,6 @@ func setInstancePhaseMetrics(provider string, account string, instance dbaasv1al
 		metricLabelInstanceName: instance.Name,
 		MetricLabelNameSpace:    instance.Namespace,
 	}).Set(phase)
-
-	log.Info("Set to ", "phase", phase)
 }
 
 // SetInstanceMetrics set the metrics for an instance

--- a/controllers/metrics/dbaas_inventory_metrics.go
+++ b/controllers/metrics/dbaas_inventory_metrics.go
@@ -41,17 +41,13 @@ func SetInventoryMetrics(inventory dbaasv1alpha1.DBaaSInventory, execution Execu
 
 // setInventoryStatusMetrics set the Metrics for inventory status
 func setInventoryStatusMetrics(inventory dbaasv1alpha1.DBaaSInventory) {
-	log := ctrl.Log.WithName("Setting DBaaSInventoryStatusGauge: ")
-	log.Info("Started")
 	for _, cond := range inventory.Status.Conditions {
 		if cond.Type == dbaasv1alpha1.DBaaSInventoryReadyType {
 			DBaaSInventoryStatusGauge.DeletePartialMatch(prometheus.Labels{MetricLabelProvider: inventory.Spec.ProviderRef.Name, MetricLabelName: inventory.Name, MetricLabelNameSpace: inventory.Namespace})
 			if cond.Reason == dbaasv1alpha1.Ready && cond.Status == metav1.ConditionTrue {
 				DBaaSInventoryStatusGauge.With(prometheus.Labels{MetricLabelProvider: inventory.Spec.ProviderRef.Name, MetricLabelName: inventory.Name, MetricLabelNameSpace: inventory.Namespace, MetricLabelStatus: string(cond.Status), MetricLabelReason: cond.Reason}).Set(1)
-				log.Info("Set to 1")
 			} else {
 				DBaaSInventoryStatusGauge.With(prometheus.Labels{MetricLabelProvider: inventory.Spec.ProviderRef.Name, MetricLabelName: inventory.Name, MetricLabelNameSpace: inventory.Namespace, MetricLabelStatus: string(cond.Status), MetricLabelReason: cond.Reason}).Set(0)
-				log.Info("Set to 0")
 			}
 			break
 		}

--- a/controllers/metrics/dbaas_platform_metrics.go
+++ b/controllers/metrics/dbaas_platform_metrics.go
@@ -6,8 +6,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 
 	dbaasv1alpha1 "github.com/RHEcosystemAppEng/dbaas-operator/api/v1alpha1"
-
-	ctrl "sigs.k8s.io/controller-runtime"
 )
 
 const (
@@ -71,12 +69,10 @@ func SetPlatformStatusMetric(platformName dbaasv1alpha1.PlatformsName, status db
 
 // setPlatformRequestDurationSeconds set the metrics for platform request duration in seconds
 func setPlatformRequestDurationSeconds(platform dbaasv1alpha1.DBaaSPlatform, account string, execution Execution, event string) {
-	log := ctrl.Log.WithName("DBaaSPlatform Request Duration for event: " + event)
 	switch event {
 	case LabelEventValueCreate:
 		duration := time.Now().UTC().Sub(platform.CreationTimestamp.Time.UTC())
 		UpdateRequestsDurationHistogram(platform.Name, account, platform.Namespace, LabelResourceValuePlatform, event, duration.Seconds())
-		log.Info("Set the request duration for create event")
 	case LabelEventValueDelete:
 		deletionTimestamp := execution.begin.UTC()
 		if platform.DeletionTimestamp != nil {
@@ -85,7 +81,6 @@ func setPlatformRequestDurationSeconds(platform dbaasv1alpha1.DBaaSPlatform, acc
 
 		duration := time.Now().UTC().Sub(deletionTimestamp.UTC())
 		UpdateRequestsDurationHistogram(platform.Name, account, platform.Namespace, LabelResourceValuePlatform, event, duration.Seconds())
-		log.Info("Set the request duration for delete event")
 	}
 }
 

--- a/controllers/metrics/dbaas_platform_metrics.go
+++ b/controllers/metrics/dbaas_platform_metrics.go
@@ -50,26 +50,21 @@ func PlatformStackInstallationMetric(platform *dbaasv1alpha1.DBaaSPlatform, vers
 
 // SetPlatformStatusMetric exposes dbaas_platform_status Metric for each platform
 func SetPlatformStatusMetric(platformName dbaasv1alpha1.PlatformsName, status dbaasv1alpha1.PlatformsInstlnStatus, version string) {
-	log := ctrl.Log.WithName("Setting DBaaSPlatformStatusGauge: ")
-	log.Info("Started")
 	if len(platformName) > 0 {
 		switch status {
 
 		case dbaasv1alpha1.ResultFailed:
 			DBaasPlatformInstallationGauge.With(prometheus.Labels{MetricLabelName: string(platformName), MetricLabelStatus: string(status), MetricLabelVersion: version}).Set(float64(0))
-			log.Info("Set to 0")
 			DBaasPlatformInstallationGauge.Delete(prometheus.Labels{MetricLabelName: string(platformName), MetricLabelStatus: string(dbaasv1alpha1.ResultSuccess), MetricLabelVersion: version})
 			DBaasPlatformInstallationGauge.Delete(prometheus.Labels{MetricLabelName: string(platformName), MetricLabelStatus: string(dbaasv1alpha1.ResultInProgress), MetricLabelVersion: version})
 		case dbaasv1alpha1.ResultSuccess:
 			DBaasPlatformInstallationGauge.Delete(prometheus.Labels{MetricLabelName: string(platformName), MetricLabelStatus: string(dbaasv1alpha1.ResultInProgress), MetricLabelVersion: version})
 			DBaasPlatformInstallationGauge.Delete(prometheus.Labels{MetricLabelName: string(platformName), MetricLabelStatus: string(dbaasv1alpha1.ResultFailed), MetricLabelVersion: version})
 			DBaasPlatformInstallationGauge.With(prometheus.Labels{MetricLabelName: string(platformName), MetricLabelStatus: string(status), MetricLabelVersion: version}).Set(float64(1))
-			log.Info("Set to 1")
 		case dbaasv1alpha1.ResultInProgress:
 			DBaasPlatformInstallationGauge.With(prometheus.Labels{MetricLabelName: string(platformName), MetricLabelStatus: string(status), MetricLabelVersion: version}).Set(float64(2))
 			DBaasPlatformInstallationGauge.Delete(prometheus.Labels{MetricLabelName: string(platformName), MetricLabelStatus: string(dbaasv1alpha1.ResultSuccess), MetricLabelVersion: version})
 			DBaasPlatformInstallationGauge.Delete(prometheus.Labels{MetricLabelName: string(platformName), MetricLabelStatus: string(dbaasv1alpha1.ResultFailed), MetricLabelVersion: version})
-			log.Info("Set to 2")
 		}
 	}
 }
@@ -96,8 +91,6 @@ func setPlatformRequestDurationSeconds(platform dbaasv1alpha1.DBaaSPlatform, acc
 
 // SetPlatformMetrics set the metrics for a platform
 func SetPlatformMetrics(platform dbaasv1alpha1.DBaaSPlatform, account string, execution Execution, event string, errCd string) {
-	log := ctrl.Log.WithName("Setting DBaaSPlatform Metrics")
-	log.Info("provider - " + platform.Name + " account - " + account + " namespace - " + platform.Namespace + " event - " + event + " errCd - " + errCd)
 	setPlatformRequestDurationSeconds(platform, account, execution, event)
 	UpdateErrorsTotal(platform.Name, account, platform.Namespace, LabelResourceValuePlatform, event, errCd)
 }


### PR DESCRIPTION
## Description
Remove logging from setConnectionStatusMetrics as it generates too much of logs

## Verification Steps
The multiple logs from setConnectionStatusMetrics should not appear, as they are deleted

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA or in issue number have been completed
- [ ] Unit tests added that prove the fix is effective or the feature works 
- [ ] Documentation added for the feature
- [ ] all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer