### PR TITLE
Revert "DBAAS-941: upgrade to RDS controller v0.1.1"

### DIFF
--- a/bundle/metadata/dependencies.yaml
+++ b/bundle/metadata/dependencies.yaml
@@ -6,4 +6,4 @@ dependencies:
   - type: olm.package
     value:
       packageName: ack-rds-controller
-      version: ">=0.0.27 <=0.1.1"
+      version: "0.0.27"


### PR DESCRIPTION
## Description
This change is causing issues during platform install. This change should be resubmitted at the same time as the RDS operator version/build is incremented, which would include https://github.com/RHEcosystemAppEng/rds-dbaas-operator/pull/15