### PR TITLE
fix the issue with crunchy operator for trial version cluster creation

### DIFF
--- a/api/v1alpha1/dbaasinstance_conversion.go
+++ b/api/v1alpha1/dbaasinstance_conversion.go
@@ -124,5 +124,9 @@ func (dst *DBaaSInstanceSpec) ConvertFrom(src *v1beta1.DBaaSInstanceSpec) error 
 		}
 		dst.OtherInstanceParams[name] = val
 	}
+	// Special tweaking for crunchy bridge
+	if inventory.Spec.ProviderRef.Name == v1beta1.CrunchyBridgeRegistration {
+		dst.CloudRegion = "us-east-1"
+	}
 	return nil
 }

--- a/api/v1alpha1/dbaasprovider_conversion.go
+++ b/api/v1alpha1/dbaasprovider_conversion.go
@@ -27,7 +27,8 @@ var ProviderFieldsMap map[string]interface{} = map[string]interface{}{
 	v1beta1.CrunchyBridgeRegistration: map[string]v1beta1.ProvisioningParameterType{
 		"Name":     v1beta1.ProvisioningName,
 		"Provider": v1beta1.ProvisioningCloudProvider,
-		"TeamID":   v1beta1.ProvisioningTeamProject,
+		// commenting TeamID parameter as it's not required for trial
+		//"TeamID":   v1beta1.ProvisioningTeamProject,
 	},
 	v1beta1.MongoDBAtlasRegistration: map[string]v1beta1.ProvisioningParameterType{
 		"clusterName":  v1beta1.ProvisioningName,


### PR DESCRIPTION
Signed-off-by: Abdul Hameed <ahameed@redhat.com>

setting the default value for cloud provider region parameter `us-east-1` for crunchy bridge operator trial version, as the dbaas instance cr only set cloud provider default aws. 

```spec:
  inventoryRef:
    name: ahameed-r5
    namespace: openshift-dbaas-operator
  provisioningParameters:
    cloudProvider: aws
    name: dbaastest
    plan: FREETRIAL
    teamProject: '': ''
```

setting region and removing the teamProject from cr, as it's not required for trail version, and it will get default.   
```
spec:
  cloudProvider: aws
  cloudRegion: us-east-1
  inventoryRef:
    name: ahameed-r5
    namespace: openshift-dbaas-operator
  name: dbaastest
  otherInstanceParams:
    Name: dbaastest
    Provider: aws
```


Removing the TeamID parameters as these are not required and avoid passing empty or any values from UI to crunchy operator, to work trial version as release4. 



## Description
<!-- Please include a summary of the change and link to the related Jira issue. Please add any additional motivation and context as needed. Screenshots are also welcome -->

## Verification Steps
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.
-->

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA or in issue number have been completed
- [ ] Unit tests added that prove the fix is effective or the feature works 
- [ ] Documentation added for the feature
- [ ] all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer