### PR TITLE
update CRDB image pointer back to official repo

### DIFF
--- a/bundle/manifests/dbaas-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/dbaas-operator.clusterserviceversion.yaml
@@ -676,9 +676,9 @@ spec:
                 - name: CSV_VERSION_MONGODB_ATLAS
                   value: mongodb-atlas-kubernetes.v0.3.0
                 - name: RELATED_IMAGE_COCKROACHDB_CATALOG
-                  value: quay.io/jianrzha/ccapi-k8s-operator-catalog:v0.0.5-dev
+                  value: gcr.io/cockroach-shared/ccapi-k8s-operator-catalog:v0.0.5
                 - name: CSV_VERSION_COCKROACHDB
-                  value: ccapi-k8s-operator.v0.0.5-dev
+                  value: ccapi-k8s-operator.v0.0.5
                 - name: RELATED_IMAGE_RDS_PROVIDER_CATALOG
                   value: quay.io/ecosystem-appeng/rds-dbaas-operator-catalog:v0.3.0
                 - name: CSV_VERSION_RDS_PROVIDER
@@ -823,7 +823,7 @@ spec:
     name: crunchy-bridge-catalog
   - image: quay.io/mongodb/mongodb-atlas-kubernetes-dbaas-catalog:0.3.0
     name: mongodb-atlas-catalog
-  - image: quay.io/jianrzha/ccapi-k8s-operator-catalog:v0.0.5-dev
+  - image: gcr.io/cockroach-shared/ccapi-k8s-operator-catalog:v0.0.5
     name: cockroachdb-catalog
   - image: quay.io/ecosystem-appeng/rds-dbaas-operator-catalog:v0.3.0
     name: rds-provider-catalog

--- a/config/default/manager-env-images.yaml
+++ b/config/default/manager-env-images.yaml
@@ -23,9 +23,9 @@ spec:
             - name: CSV_VERSION_MONGODB_ATLAS
               value: mongodb-atlas-kubernetes.v0.3.0
             - name: RELATED_IMAGE_COCKROACHDB_CATALOG
-              value: quay.io/jianrzha/ccapi-k8s-operator-catalog:v0.0.5-dev
+              value: gcr.io/cockroach-shared/ccapi-k8s-operator-catalog:v0.0.5
             - name: CSV_VERSION_COCKROACHDB
-              value: ccapi-k8s-operator.v0.0.5-dev
+              value: ccapi-k8s-operator.v0.0.5
             - name: RELATED_IMAGE_RDS_PROVIDER_CATALOG
               value: quay.io/ecosystem-appeng/rds-dbaas-operator-catalog:v0.3.0
             - name: CSV_VERSION_RDS_PROVIDER


### PR DESCRIPTION
CRDB image is pushed (v0.0.5 to match RHODA 0.4.0), update back to their repo