### PR TITLE
DBAAS-1193: workaround to the ack-rds-controller v0.1.3 upgrade issue

### DIFF
--- a/controllers/dbaas_controllers_common_test.go
+++ b/controllers/dbaas_controllers_common_test.go
@@ -176,6 +176,27 @@ func assertResourceDeletion(object client.Object) func() {
 	}
 }
 
+func assertResourceDeletionIfNotExists(object client.Object) func() {
+	return func() {
+		By("checking the resource exists")
+		var del = true
+		Eventually(func() bool {
+			if err := dRec.Get(ctx, client.ObjectKeyFromObject(object), object); err != nil {
+				if errors.IsNotFound(err) {
+					del = false
+					return true
+				}
+				return false
+			}
+			return true
+		}, timeout).Should(BeTrue())
+
+		if del {
+			assertResourceDeletion(object)()
+		}
+	}
+}
+
 func assertProviderResourceCreated(object client.Object, groupVersion schema.GroupVersion, providerResourceKind string, DBaaSResourceSpec interface{}) func() {
 	return func() {
 		By("checking a provider resource created")


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and link to the related Jira issue. Please add any additional motivation and context as needed. Screenshots are also welcome -->

With ack-rds-controller v0.1.3, the label selector of the deployment of the operator is changed. 
However, this field is immutable. 
As a result, upgrading ack-rds-controller from an older version to v0.1.3 fails.


Jira: https://issues.redhat.com/browse/DBAAS-1193

The workaround is to use the RHODA operator to check the status of the ack-rds-controller v0.1.3 csv. 
If the upgrade issue is detected, RHODA operator will delete the deployment of the ack-rds-controller.
Then the deployment of the ack-rds-controller will be re-created automatically, and the upgrade will contiune.

## Verification Steps
<!--
Add the steps required to check this change. Following an example.
1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.
-->

Upgrading RHODA v0.0.3 to 0.0.4.
Check if the upgrade succeeds and if the ack-rds-controller is upgraded to v0.1.3.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA or in issue number have been completed
- [ ] Unit tests added that prove the fix is effective or the feature works 
- [ ] Documentation added for the feature
- [ ] all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer