### PR TITLE
Fix metrics to show creation time of objects on grafana dashboard

### DIFF
--- a/controllers/dbaasplatform_controller.go
+++ b/controllers/dbaasplatform_controller.go
@@ -161,7 +161,7 @@ func (r *DBaaSPlatformReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	if err != nil {
 		logger.Error(err, "Error in getting of openshift platform Type")
 	}
-	metrics.SetOpenShiftInstallationInfoMetric(r.operatorNameVersion, consoleURL, string(platformType))
+	metrics.SetOpenShiftInstallationInfoMetric(r.operatorNameVersion, consoleURL, string(platformType), cr.CreationTimestamp.String())
 	if cr.DeletionTimestamp == nil {
 		platforms = reconcilers.InstallationPlatforms
 	}

--- a/controllers/metrics/dbaas_connection_metrics.go
+++ b/controllers/metrics/dbaas_connection_metrics.go
@@ -34,7 +34,7 @@ const (
 var DBaaSConnectionStatusGauge = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 	Name: MetricNameConnectionStatusReady,
 	Help: "The status of DBaaS connections, values ( ready=1, error / not ready=0 )",
-}, []string{MetricLabelProvider, MetricLabelAccountName, MetricLabelInstanceID, MetricLabelConnectionName, MetricLabelNameSpace, MetricLabelStatus, MetricLabelReason})
+}, []string{MetricLabelProvider, MetricLabelAccountName, MetricLabelInstanceID, MetricLabelConnectionName, MetricLabelNameSpace, MetricLabelStatus, MetricLabelReason, MetricLabelCreationTimestamp})
 
 // SetConnectionMetrics set the Metrics for a connection
 func SetConnectionMetrics(provider string, account string, connection dbaasv1beta1.DBaaSConnection, execution Execution, event string, errCd string) {
@@ -51,9 +51,9 @@ func setConnectionStatusMetrics(provider string, account string, connection dbaa
 		if cond.Type == dbaasv1beta1.DBaaSConnectionReadyType {
 			DBaaSConnectionStatusGauge.DeletePartialMatch(prometheus.Labels{MetricLabelName: connection.Name, MetricLabelNameSpace: connection.Namespace})
 			if cond.Reason == dbaasv1beta1.Ready && cond.Status == metav1.ConditionTrue {
-				DBaaSConnectionStatusGauge.With(prometheus.Labels{MetricLabelProvider: provider, MetricLabelAccountName: account, MetricLabelInstanceID: connection.Spec.DatabaseServiceID, MetricLabelConnectionName: connection.GetName(), MetricLabelNameSpace: connection.Namespace, MetricLabelStatus: string(cond.Status), MetricLabelReason: cond.Reason}).Set(1)
+				DBaaSConnectionStatusGauge.With(prometheus.Labels{MetricLabelProvider: provider, MetricLabelAccountName: account, MetricLabelInstanceID: connection.Spec.DatabaseServiceID, MetricLabelConnectionName: connection.GetName(), MetricLabelNameSpace: connection.Namespace, MetricLabelStatus: string(cond.Status), MetricLabelReason: cond.Reason, MetricLabelCreationTimestamp: connection.CreationTimestamp.String()}).Set(1)
 			} else {
-				DBaaSConnectionStatusGauge.With(prometheus.Labels{MetricLabelProvider: provider, MetricLabelAccountName: account, MetricLabelInstanceID: connection.Spec.DatabaseServiceID, MetricLabelConnectionName: connection.GetName(), MetricLabelNameSpace: connection.Namespace, MetricLabelStatus: string(cond.Status), MetricLabelReason: cond.Reason}).Set(0)
+				DBaaSConnectionStatusGauge.With(prometheus.Labels{MetricLabelProvider: provider, MetricLabelAccountName: account, MetricLabelInstanceID: connection.Spec.DatabaseServiceID, MetricLabelConnectionName: connection.GetName(), MetricLabelNameSpace: connection.Namespace, MetricLabelStatus: string(cond.Status), MetricLabelReason: cond.Reason, MetricLabelCreationTimestamp: connection.CreationTimestamp.String()}).Set(0)
 			}
 			break
 		}

--- a/controllers/metrics/dbaas_instance_metrics.go
+++ b/controllers/metrics/dbaas_instance_metrics.go
@@ -33,7 +33,7 @@ const (
 var DBaaSInstanceStatusGauge = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 	Name: metricNameInstanceStatusReady,
 	Help: "The status of DBaaS instance, values ( ready=1, error / not ready=0 )",
-}, []string{MetricLabelProvider, MetricLabelAccountName, metricLabelInstanceName, MetricLabelNameSpace, MetricLabelStatus, MetricLabelReason})
+}, []string{MetricLabelProvider, MetricLabelAccountName, metricLabelInstanceName, MetricLabelNameSpace, MetricLabelStatus, MetricLabelReason, MetricLabelCreationTimestamp})
 
 // DBaaSInstancePhaseGauge defines a gauge for DBaaSInstancePhase
 var DBaaSInstancePhaseGauge = prometheus.NewGaugeVec(prometheus.GaugeOpts{
@@ -47,9 +47,9 @@ func setInstanceStatusMetrics(provider string, account string, instance dbaasv1b
 		if cond.Type == dbaasv1beta1.DBaaSInstanceReadyType {
 			DBaaSInstanceStatusGauge.DeletePartialMatch(prometheus.Labels{metricLabelInstanceName: instance.GetName(), MetricLabelNameSpace: instance.Namespace})
 			if cond.Reason == dbaasv1beta1.Ready && cond.Status == metav1.ConditionTrue {
-				DBaaSInstanceStatusGauge.With(prometheus.Labels{MetricLabelProvider: provider, MetricLabelAccountName: account, metricLabelInstanceName: instance.GetName(), MetricLabelNameSpace: instance.Namespace, MetricLabelStatus: string(cond.Status), MetricLabelReason: cond.Reason}).Set(1)
+				DBaaSInstanceStatusGauge.With(prometheus.Labels{MetricLabelProvider: provider, MetricLabelAccountName: account, metricLabelInstanceName: instance.GetName(), MetricLabelNameSpace: instance.Namespace, MetricLabelStatus: string(cond.Status), MetricLabelReason: cond.Reason, MetricLabelCreationTimestamp: instance.CreationTimestamp.String()}).Set(1)
 			} else {
-				DBaaSInstanceStatusGauge.With(prometheus.Labels{MetricLabelProvider: provider, MetricLabelAccountName: account, metricLabelInstanceName: instance.GetName(), MetricLabelNameSpace: instance.Namespace, MetricLabelStatus: string(cond.Status), MetricLabelReason: cond.Reason}).Set(0)
+				DBaaSInstanceStatusGauge.With(prometheus.Labels{MetricLabelProvider: provider, MetricLabelAccountName: account, metricLabelInstanceName: instance.GetName(), MetricLabelNameSpace: instance.Namespace, MetricLabelStatus: string(cond.Status), MetricLabelReason: cond.Reason, MetricLabelCreationTimestamp: instance.CreationTimestamp.String()}).Set(0)
 			}
 			break
 		}

--- a/controllers/metrics/dbaas_inventory_metrics.go
+++ b/controllers/metrics/dbaas_inventory_metrics.go
@@ -30,7 +30,7 @@ const (
 var DBaaSInventoryStatusGauge = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 	Name: MetricNameInventoryStatusReady,
 	Help: "The status of DBaaS Provider Account, values ( ready=1, error / not ready=0 )",
-}, []string{MetricLabelProvider, MetricLabelName, MetricLabelNameSpace, MetricLabelStatus, MetricLabelReason})
+}, []string{MetricLabelProvider, MetricLabelName, MetricLabelNameSpace, MetricLabelStatus, MetricLabelReason, MetricLabelCreationTimestamp})
 
 // SetInventoryMetrics set the Metrics for inventory
 func SetInventoryMetrics(inventory dbaasv1beta1.DBaaSInventory, execution Execution, event string, errCd string) {
@@ -45,9 +45,9 @@ func setInventoryStatusMetrics(inventory dbaasv1beta1.DBaaSInventory) {
 		if cond.Type == dbaasv1beta1.DBaaSInventoryReadyType {
 			DBaaSInventoryStatusGauge.DeletePartialMatch(prometheus.Labels{MetricLabelProvider: inventory.Spec.ProviderRef.Name, MetricLabelName: inventory.Name, MetricLabelNameSpace: inventory.Namespace})
 			if cond.Reason == dbaasv1beta1.Ready && cond.Status == metav1.ConditionTrue {
-				DBaaSInventoryStatusGauge.With(prometheus.Labels{MetricLabelProvider: inventory.Spec.ProviderRef.Name, MetricLabelName: inventory.Name, MetricLabelNameSpace: inventory.Namespace, MetricLabelStatus: string(cond.Status), MetricLabelReason: cond.Reason}).Set(1)
+				DBaaSInventoryStatusGauge.With(prometheus.Labels{MetricLabelProvider: inventory.Spec.ProviderRef.Name, MetricLabelName: inventory.Name, MetricLabelNameSpace: inventory.Namespace, MetricLabelStatus: string(cond.Status), MetricLabelReason: cond.Reason, MetricLabelCreationTimestamp: inventory.CreationTimestamp.String()}).Set(1)
 			} else {
-				DBaaSInventoryStatusGauge.With(prometheus.Labels{MetricLabelProvider: inventory.Spec.ProviderRef.Name, MetricLabelName: inventory.Name, MetricLabelNameSpace: inventory.Namespace, MetricLabelStatus: string(cond.Status), MetricLabelReason: cond.Reason}).Set(0)
+				DBaaSInventoryStatusGauge.With(prometheus.Labels{MetricLabelProvider: inventory.Spec.ProviderRef.Name, MetricLabelName: inventory.Name, MetricLabelNameSpace: inventory.Namespace, MetricLabelStatus: string(cond.Status), MetricLabelReason: cond.Reason, MetricLabelCreationTimestamp: inventory.CreationTimestamp.String()}).Set(0)
 			}
 			break
 		}

--- a/controllers/metrics/metrics.go
+++ b/controllers/metrics/metrics.go
@@ -62,7 +62,7 @@ var DBaasStackInstallationHistogram = prometheus.NewHistogramVec(prometheus.Hist
 var DBaasOperatorVersionInfo = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 	Name: MetricNameOperatorVersion,
 	Help: "The current version of DBaaS Operator installed in the cluster",
-}, []string{MetricLabelVersion, MetricLabelConsoleULR, MetricLabelPlatformName})
+}, []string{MetricLabelVersion, MetricLabelConsoleULR, MetricLabelPlatformName, MetricLabelCreationTimestamp})
 
 // DBaaSRequestsDurationHistogram DBaaS Requests Duration Histogram for all DBaaS Resources
 var DBaaSRequestsDurationHistogram = prometheus.NewHistogramVec(
@@ -93,8 +93,8 @@ func PlatformInstallStart() Execution {
 }
 
 // SetOpenShiftInstallationInfoMetric set the Metrics for openshift info
-func SetOpenShiftInstallationInfoMetric(operatorVersion string, consoleURL string, platformType string) {
-	DBaasOperatorVersionInfo.With(prometheus.Labels{MetricLabelVersion: operatorVersion, MetricLabelConsoleULR: consoleURL, MetricLabelPlatformName: platformType}).Set(1)
+func SetOpenShiftInstallationInfoMetric(operatorVersion string, consoleURL string, platformType string, creationTime string) {
+	DBaasOperatorVersionInfo.With(prometheus.Labels{MetricLabelVersion: operatorVersion, MetricLabelConsoleULR: consoleURL, MetricLabelPlatformName: platformType, MetricLabelCreationTimestamp: creationTime}).Set(1)
 }
 
 // UpdateRequestsDurationHistogram Utility function to update request duration histogram


### PR DESCRIPTION
adding back the creation time label in metrics for invenotry/connection/istnance to know when the these object created, and to show on grafana.  

![Screenshot 2023-02-09 at 10 57 00 AM](https://user-images.githubusercontent.com/41960152/217869294-98f219ec-3207-4b8f-b98d-32c637fe2157.png)


Signed-off-by: Abdul Hameed <ahameed@redhat.com>

## Description
<!-- Please include a summary of the change and link to the related Jira issue. Please add any additional motivation and context as needed. Screenshots are also welcome -->

## Verification Steps
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.
-->

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA or in issue number have been completed
- [ ] Unit tests added that prove the fix is effective or the feature works 
- [ ] Documentation added for the feature
- [ ] all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer