### PR TITLE
[DBAAS-1103 ]setting log verbosity level

### DIFF
--- a/controllers/dbaasconnection_controller.go
+++ b/controllers/dbaasconnection_controller.go
@@ -254,7 +254,7 @@ func (r *DBaaSConnectionReconciler) Delete(e event.DeleteEvent) error {
 	execution := metrics.PlatformInstallStart()
 	metricLabelErrCdValue := ""
 	log := ctrl.Log.WithName("DBaaSConnectionReconciler DeleteEvent")
-	log.Info("Delete event started")
+	log.V(1).Info("Delete event started")
 
 	connectionObj, ok := e.Object.(*v1beta1.DBaaSConnection)
 	if !ok {
@@ -262,12 +262,12 @@ func (r *DBaaSConnectionReconciler) Delete(e event.DeleteEvent) error {
 		metricLabelErrCdValue = metrics.LabelErrorCdValueErrorDeletingConnection
 		return nil
 	}
-	log.Info("connectionObj", "connectionObj", objectKeyFromObject(connectionObj))
+	log.V(1).Info("connectionObj", "connectionObj", objectKeyFromObject(connectionObj))
 
 	inventory := &v1beta1.DBaaSInventory{}
 	_ = r.Get(context.TODO(), types.NamespacedName{Namespace: connectionObj.Spec.InventoryRef.Namespace, Name: connectionObj.Spec.InventoryRef.Name}, inventory)
 
-	log.Info("Calling metrics for deleting of DBaaSConnection")
+	log.V(1).Info("Calling metrics for deleting of DBaaSConnection")
 	metrics.SetConnectionMetrics(inventory.Spec.ProviderRef.Name, inventory.Name, *connectionObj, execution, metrics.LabelEventValueDelete, metricLabelErrCdValue)
 
 	return nil

--- a/controllers/dbaasinstance_controller.go
+++ b/controllers/dbaasinstance_controller.go
@@ -189,7 +189,7 @@ func (r *DBaaSInstanceReconciler) Delete(e event.DeleteEvent) error {
 	execution := metrics.PlatformInstallStart()
 	metricLabelErrCdValue := ""
 	log := ctrl.Log.WithName("DBaaSInstanceReconciler DeleteEvent")
-	log.Info("Delete event started")
+	log.V(1).Info("Delete event started")
 
 	instanceObj, ok := e.Object.(*v1beta1.DBaaSInstance)
 	if !ok {
@@ -197,13 +197,13 @@ func (r *DBaaSInstanceReconciler) Delete(e event.DeleteEvent) error {
 		metricLabelErrCdValue = metrics.LabelErrorCdValueErrorDeletingInstance
 		return nil
 	}
-	log.Info("instanceObj", "instanceObj", objectKeyFromObject(instanceObj))
+	log.V(1).Info("instanceObj", "instanceObj", objectKeyFromObject(instanceObj))
 
 	inventory := &v1beta1.DBaaSInventory{}
 	_ = r.Get(context.TODO(), types.NamespacedName{Namespace: instanceObj.Spec.InventoryRef.Namespace, Name: instanceObj.Spec.InventoryRef.Name}, inventory)
 
 	defer func() {
-		log.Info("Calling metrics for deleting of DBaaSInstance")
+		log.V(1).Info("Calling metrics for deleting of DBaaSInstance")
 		metrics.SetInstanceMetrics(inventory.Spec.ProviderRef.Name, inventory.Name, *instanceObj, execution, metrics.LabelEventValueDelete, metricLabelErrCdValue)
 	}()
 

--- a/controllers/dbaasinventory_controller.go
+++ b/controllers/dbaasinventory_controller.go
@@ -203,10 +203,10 @@ func (r *DBaaSInventoryReconciler) Delete(e event.DeleteEvent) error {
 		return nil
 	}
 
-	log.Info("inventoryObj", "inventoryObj", objectKeyFromObject(inventory))
+	log.V(1).Info("inventoryObj", "inventoryObj", objectKeyFromObject(inventory))
 
 	defer func() {
-		log.Info("Calling metrics for deleting of DBaaSInventory")
+		log.V(1).Info("Calling metrics for deleting of DBaaSInventory")
 		metrics.SetInventoryMetrics(*inventory, execution, metrics.LabelEventValueDelete, metricLabelErrCdValue)
 	}()
 

--- a/controllers/dbaasplatform_controller.go
+++ b/controllers/dbaasplatform_controller.go
@@ -370,7 +370,7 @@ func (r *DBaaSPlatformReconciler) Delete(e event.DeleteEvent) error {
 	execution := metrics.PlatformInstallStart()
 	metricLabelErrCdValue := ""
 	log := ctrl.Log.WithName("DBaaSPlatformReconciler DeleteEvent")
-	log.Info("Delete event started")
+	log.V(1).Info("Delete event started")
 
 	platformObj, ok := e.Object.(*v1beta1.DBaaSPlatform)
 	if !ok {
@@ -378,9 +378,9 @@ func (r *DBaaSPlatformReconciler) Delete(e event.DeleteEvent) error {
 		metricLabelErrCdValue = metrics.LabelErrorCdValueErrorDeletingPlatform
 		return nil
 	}
-	log.Info("platformObj", "platformObj", objectKeyFromObject(platformObj))
+	log.V(1).Info("platformObj", "platformObj", objectKeyFromObject(platformObj))
 
-	log.Info("Calling metrics for deleting of DBaaSProvider")
+	log.V(1).Info("Calling metrics for deleting of DBaaSProvider")
 	metrics.SetPlatformMetrics(*platformObj, platformObj.Name, execution, metrics.LabelEventValueDelete, metricLabelErrCdValue)
 
 	return nil

--- a/controllers/dbaaspolicy_controller.go
+++ b/controllers/dbaaspolicy_controller.go
@@ -178,7 +178,7 @@ func (r *DBaaSPolicyReconciler) Delete(e event.DeleteEvent) error {
 	execution := metrics.PlatformInstallStart()
 	metricLabelErrCdValue := ""
 	log := ctrl.Log.WithName("DBaaSPolicyReconciler DeleteEvent")
-	log.Info("Delete event started")
+	log.V(1).Info("Delete event started")
 
 	policyObj, ok := e.Object.(*v1beta1.DBaaSPolicy)
 	if !ok {
@@ -186,9 +186,9 @@ func (r *DBaaSPolicyReconciler) Delete(e event.DeleteEvent) error {
 		metricLabelErrCdValue = metrics.LabelErrorCdValueErrorDeletingPolicy
 		return nil
 	}
-	log.Info("policyObj", "policyObj", objectKeyFromObject(policyObj))
+	log.V(1).Info("policyObj", "policyObj", objectKeyFromObject(policyObj))
 
-	log.Info("Calling metrics for deleting of DBaaSPolicy")
+	log.V(1).Info("Calling metrics for deleting of DBaaSPolicy")
 	metrics.SetPolicyMetrics(*policyObj, execution, metrics.LabelEventValueDelete, metricLabelErrCdValue)
 
 	return nil

--- a/controllers/dbaasprovider_controller.go
+++ b/controllers/dbaasprovider_controller.go
@@ -129,7 +129,7 @@ func (r *DBaaSProviderReconciler) Delete(e event.DeleteEvent) error {
 	execution := metrics.PlatformInstallStart()
 	metricLabelErrCdValue := ""
 	log := ctrl.Log.WithName("DBaaSProviderReconciler DeleteEvent")
-	log.Info("Delete event started")
+	log.V(1).Info("Delete event started")
 
 	providerObj, ok := e.Object.(*v1beta1.DBaaSProvider)
 	if !ok {
@@ -137,9 +137,6 @@ func (r *DBaaSProviderReconciler) Delete(e event.DeleteEvent) error {
 		metricLabelErrCdValue = metrics.LabelErrorCdValueErrorDeletingProvider
 		return nil
 	}
-	log.Info("providerObj", "providerObj", objectKeyFromObject(providerObj))
-
-	log.Info("Calling metrics for deleting of DBaaSProvider")
 	metrics.SetProviderMetrics(*providerObj, providerObj.Name, execution, metrics.LabelEventValueDelete, metricLabelErrCdValue)
 
 	return nil

--- a/controllers/metrics/dbaas_connection_metrics.go
+++ b/controllers/metrics/dbaas_connection_metrics.go
@@ -39,7 +39,7 @@ var DBaaSConnectionStatusGauge = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 // SetConnectionMetrics set the Metrics for a connection
 func SetConnectionMetrics(provider string, account string, connection dbaasv1beta1.DBaaSConnection, execution Execution, event string, errCd string) {
 	log := ctrl.Log.WithName("Setting DBaaSConnection Metrics")
-	log.Info("provider - " + provider + " account - " + account + " namespace - " + connection.Namespace + " event - " + event + " errCd - " + errCd)
+	log.V(1).Info("provider - " + provider + " account - " + account + " namespace - " + connection.Namespace + " event - " + event + " errCd - " + errCd)
 	setConnectionStatusMetrics(provider, account, connection)
 	setConnectionRequestDurationSeconds(provider, account, connection, execution, event)
 	UpdateErrorsTotal(provider, account, connection.Namespace, LabelResourceValueConnection, event, errCd)
@@ -70,7 +70,7 @@ func setConnectionRequestDurationSeconds(provider string, account string, connec
 				if cond.Status == metav1.ConditionTrue {
 					duration := time.Now().UTC().Sub(connection.CreationTimestamp.Time.UTC())
 					UpdateRequestsDurationHistogram(provider, connection.Name, connection.Namespace, LabelResourceValueConnection, event, duration.Seconds())
-					log.Info("Set the request duration for create event")
+					log.V(1).Info("Set the request duration for create event")
 				}
 			}
 		}
@@ -82,6 +82,6 @@ func setConnectionRequestDurationSeconds(provider string, account string, connec
 
 		duration := time.Now().UTC().Sub(deletionTimestamp.UTC())
 		UpdateRequestsDurationHistogram(provider, connection.Name, connection.Namespace, LabelResourceValueConnection, event, duration.Seconds())
-		log.Info("Set the request duration for delete event")
+		log.V(1).Info("Set the request duration for delete event")
 	}
 }

--- a/controllers/metrics/dbaas_instance_metrics.go
+++ b/controllers/metrics/dbaas_instance_metrics.go
@@ -59,6 +59,7 @@ func setInstanceStatusMetrics(provider string, account string, instance dbaasv1b
 // setInstanceRequestDurationSeconds set the metrics for instance request duration in seconds
 func setInstanceRequestDurationSeconds(provider string, account string, instance dbaasv1beta1.DBaaSInstance, execution Execution, event string) {
 	log := ctrl.Log.WithName("DBaaSInstance Request Duration for event: " + event)
+	log.V(0)
 	switch event {
 	case LabelEventValueCreate:
 		for _, cond := range instance.Status.Conditions {
@@ -66,7 +67,7 @@ func setInstanceRequestDurationSeconds(provider string, account string, instance
 				if cond.Status == metav1.ConditionTrue {
 					duration := time.Now().UTC().Sub(instance.CreationTimestamp.Time.UTC())
 					UpdateRequestsDurationHistogram(provider, instance.Name, instance.Namespace, LabelResourceValueInstance, event, duration.Seconds())
-					log.Info("Set the request duration for create event")
+					log.V(1).Info("Set the request duration for create event")
 				}
 			}
 		}
@@ -78,7 +79,7 @@ func setInstanceRequestDurationSeconds(provider string, account string, instance
 
 		duration := time.Now().UTC().Sub(deletionTimestamp.UTC())
 		UpdateRequestsDurationHistogram(provider, instance.Name, instance.Namespace, LabelResourceValueInstance, event, duration.Seconds())
-		log.Info("Set the request duration for delete event")
+		log.V(1).Info("Set the request duration for delete event")
 	}
 }
 
@@ -116,7 +117,7 @@ func setInstancePhaseMetrics(provider string, account string, instance dbaasv1be
 // SetInstanceMetrics set the metrics for an instance
 func SetInstanceMetrics(provider string, account string, instance dbaasv1beta1.DBaaSInstance, execution Execution, event string, errCd string) {
 	log := ctrl.Log.WithName("Setting DBaaSInstance Metrics")
-	log.Info("provider - " + provider + " account - " + account + " namespace - " + instance.Namespace + " event - " + event + " errCd - " + errCd)
+	log.V(1).Info("provider - " + provider + " account - " + account + " namespace - " + instance.Namespace + " event - " + event + " errCd - " + errCd)
 	setInstanceStatusMetrics(provider, account, instance)
 	setInstancePhaseMetrics(provider, account, instance)
 	setInstanceRequestDurationSeconds(provider, account, instance, execution, event)

--- a/controllers/metrics/dbaas_inventory_metrics.go
+++ b/controllers/metrics/dbaas_inventory_metrics.go
@@ -65,7 +65,7 @@ func setInventoryRequestDurationSeconds(inventory dbaasv1beta1.DBaaSInventory, e
 				if cond.Status == metav1.ConditionTrue {
 					duration := time.Now().UTC().Sub(inventory.CreationTimestamp.Time.UTC())
 					UpdateRequestsDurationHistogram(inventory.Spec.ProviderRef.Name, inventory.Name, inventory.Namespace, LabelResourceValueInventory, event, duration.Seconds())
-					log.Info("Set the request duration for create event")
+					log.V(1).Info("Set the request duration for create event")
 				}
 				break
 			}
@@ -79,6 +79,6 @@ func setInventoryRequestDurationSeconds(inventory dbaasv1beta1.DBaaSInventory, e
 
 		duration := time.Now().UTC().Sub(deletionTimestamp.UTC())
 		UpdateRequestsDurationHistogram(inventory.Spec.ProviderRef.Name, inventory.Name, inventory.Namespace, LabelResourceValueInventory, event, duration.Seconds())
-		log.Info("Set the request duration for delete event")
+		log.V(1).Info("Set the request duration for delete event")
 	}
 }

--- a/controllers/metrics/dbaas_policy_metrics.go
+++ b/controllers/metrics/dbaas_policy_metrics.go
@@ -33,7 +33,7 @@ func setPolicyRequestDurationSeconds(policy dbaasv1beta1.DBaaSPolicy, event stri
 	case LabelEventValueCreate:
 		duration := time.Now().UTC().Sub(policy.CreationTimestamp.Time.UTC())
 		UpdateRequestsDurationHistogram(LabelValueNone, policy.Name, policy.Namespace, LabelResourceValuePolicy, event, duration.Seconds())
-		log.Info("Set the request duration for create event")
+		log.V(1).Info("Set the request duration for create event")
 
 	case LabelEventValueDelete:
 		deletionTimestamp := execution.begin.UTC()
@@ -43,6 +43,6 @@ func setPolicyRequestDurationSeconds(policy dbaasv1beta1.DBaaSPolicy, event stri
 
 		duration := time.Now().UTC().Sub(deletionTimestamp.UTC())
 		UpdateRequestsDurationHistogram(LabelValueNone, policy.Name, policy.Namespace, LabelResourceValuePolicy, event, duration.Seconds())
-		log.Info("Set the request duration for delete event")
+		log.V(1).Info("Set the request duration for delete event")
 	}
 }

--- a/controllers/metrics/dbaas_provider_metrics.go
+++ b/controllers/metrics/dbaas_provider_metrics.go
@@ -27,7 +27,7 @@ func setProviderRequestDurationSeconds(provider dbaasv1beta1.DBaaSProvider, acco
 	case LabelEventValueCreate:
 		duration := time.Now().UTC().Sub(provider.CreationTimestamp.Time.UTC())
 		UpdateRequestsDurationHistogram(provider.Name, account, provider.Namespace, LabelResourceValueProvider, event, duration.Seconds())
-		log.Info("Set the request duration for create event")
+		log.V(1).Info("Set the request duration for create event")
 	case LabelEventValueDelete:
 		deletionTimestamp := execution.begin.UTC()
 		if provider.DeletionTimestamp != nil {
@@ -36,14 +36,14 @@ func setProviderRequestDurationSeconds(provider dbaasv1beta1.DBaaSProvider, acco
 
 		duration := time.Now().UTC().Sub(deletionTimestamp.UTC())
 		UpdateRequestsDurationHistogram(provider.Name, account, provider.Namespace, LabelResourceValueProvider, event, duration.Seconds())
-		log.Info("Set the request duration for delete event")
+		log.V(1).Info("Set the request duration for delete event")
 	}
 }
 
 // SetProviderMetrics set the metrics for a provider
 func SetProviderMetrics(provider dbaasv1beta1.DBaaSProvider, account string, execution Execution, event string, errCd string) {
 	log := ctrl.Log.WithName("Setting DBaaSProvider Metrics")
-	log.Info("provider - " + provider.Name + " account - " + account + " namespace - " + provider.Namespace + " event - " + event + " errCd - " + errCd)
+	log.V(1).Info("provider - " + provider.Name + " account - " + account + " namespace - " + provider.Namespace + " event - " + event + " errCd - " + errCd)
 	setProviderRequestDurationSeconds(provider, account, execution, event)
 	UpdateErrorsTotal(provider.Name, account, provider.Namespace, LabelResourceValueProvider, event, errCd)
 }


### PR DESCRIPTION

## Description
set log verbosity level to show some of the logs in just debugging mod.

## Verification Steps

Add the steps required to check this change. Following an example.

1. Deploy the operator 
2. change the level debug for manager container -> `--zap-log-level=debug` can be done in editing CSV file


      ```
                    args:
                      - '--health-probe-bind-address=:8081'
                      - '--metrics-bind-address=0.0.0.0:8080'
                      - '--leader-elect'
                      - '--zap-log-level=debug'
                      
```


5.verify the debug log is showing.

``` 2023-02-13T17:03:49.224Z DEBUG DBaaSConnectionReconciler DeleteEvent Delete event started
2023-02-13T17:03:49.224Z DEBUG DBaaS Connection resource not found, has been deleted {"controller": "dbaasconnection", "controllerGroup": "dbaas.redhat.com", "controllerKind": "DBaaSConnection", "DBaaSConnection": {"name":"test0130-37654a8e7e","namespace":"olavtar"}, "namespace": "olavtar", "name": "test0130-37654a8e7e", "reconcileID": "3b3eb861-26e7-49e6-bc91-70d0acadbd12"}
2023-02-13T17:03:49.224Z DEBUG DBaaSConnectionReconciler DeleteEvent connectionObj {"connectionObj": "olavtar/test0130-37654a8e7e"}
2023-02-13T17:03:49.224Z DEBUG DBaaSConnectionReconciler DeleteEvent Calling metrics for deleting of DBaaSConnection
2023-02-13T17:03:49.224Z DEBUG Setting DBaaSConnection Metrics provider - account - namespace - olavtar event - delete errCd -
2023-02-13T17:03:49.225Z DEBUG Connection Request Duration for event: delete Set the request duration for delete event
2023-02-13T17:03:49.260Z DEBUG DBaaS Connection resource not found, has been deleted {"controller": "dbaasconnection", "controllerGroup": "dbaas.redhat.com", "controllerKind": "DBaaSConnection", "DBaaSConnection": {"name":"test0130-37654a8e7e","namespace":"olavtar"}, "namespace": "olavtar", "name": "test0130-37654a8e7e", "reconcileID": "7e0bb36d-7831-4da0-965c-3e1f9bf1dc5e"}
2023-02-13T17:03:59.481Z DEBUG DBaaS Connection resource not found, has been deleted {"controller": "dbaasconnection", "controllerGroup": "dbaas.redhat.com", "controllerKind": "DBaaSConnection", "DBaaSConnection": {"name":"test0130-37654a8e7e","namespace":"

2023-02-13T17:13:36.186Z DEBUG DBaaSConnectionReconciler DeleteEvent connectionObj {"connectionObj": "openshift-dbaas-operator/test0130-37654a8e7e"}
2023-02-13T17:13:36.186Z DEBUG DBaaSConnectionReconciler DeleteEvent Calling metrics for deleting of DBaaSConnection
2023-02-13T17:13:36.186Z DEBUG Setting DBaaSConnection Metrics provider - cockroachdb-cloud-registration account - my-db-provider-account-crdb namespace - openshift-dbaas-operator event - delete errCd -
2023-02-13T17:13:36.186Z DEBUG Connection Request Duration for event: delete Set the request duration for delete event
2023-02-13T17:13:36.186Z DEBUG DBaaS Connection resource not found, has been deleted {"controller": "dbaasconnection", "controllerGroup": "dbaas.redhat.com", "controllerKind": "DBaaSConnection", "DBaaSConnection": {"name":"test0130-37654a8e7e","namespace":"openshift-dbaas-operator"}, "namespace": "openshift-dbaas-operator", "name": "test0130-37654a8e7e", "reconcileID": "d2409db8-59b2-45cd-babf-ca96c5e751fc"}
2023-02-13T17:13:36.228Z DEBUG DBaaS Connection resource not found, has been deleted {"controller": "dbaasconnection", "controllerGroup": "dbaas.redhat.com", "controllerKind": "DBaaSConnection", "DBaaSConnection": {"name":"test0130-37654a8e7e","namespace":"openshift-dbaas-operator"}, "namespace": "openshift-dbaas-operator", "name": "test0130-37654a8e7e", "reconcileID": "aa071a79-b8d7-4eaa-9b79-9dc4e06978b5"}
2023-02-13T17:14:12.452Z DEBUG DBaaSConnectionReconciler DeleteEvent Delete event started
2023-02-13T17:14:12.452Z DEBUG DBaaSConnectionReconciler DeleteEvent connectionObj {"connectionObj": "olavtar2/test0130-37654a8e7e"}
2023-02-13T17:14:12.452Z DEBUG DBaaSConnectionReconciler DeleteEvent Calling metrics for deleting of DBaaSConnection
2023-02-13T17:14:12.452Z DEBUG Setting DBaaSConnection Metrics provider - cockroachdb-cloud-registration account - olga-db-provider-account namespace - olavtar2 event - delete errCd -
2023-02-13T17:14:12.452Z DEBUG Connection Request Duration for event: delete Set the request duration for delete event
2023-02-13T17:14:12.452Z DEBUG DBaaS Connection resource not found, has been deleted {"controller": "dbaasconnection", "controllerGroup": "dbaas.redhat.com", "controllerKind": "DBaaSConnection", "DBaaSConnection": {"name":"test0130-37654a8e7e","namespace":"olavtar2"}, "namespace": "olavtar2", "name": "test0130-37654a8e7e", "reconcileID": "06660ab1-65b2-4a85-99b7-af20d152a206"}
2023-02-13T17:14:12.484Z DEBUG DBaaS Connection resource not found, has been deleted {"controller": "dbaasconnection", "controllerGroup": "dbaas.redhat.com", "controllerKind": "DBaaSConnection", "DBaaSConnection": {"name":"test0130-37654a8e7e","name 
```

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA or in issue number have been completed
- [ ] Unit tests added that prove the fix is effective or the feature works 
- [ ] Documentation added for the feature
- [ ] all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer